### PR TITLE
Terraform

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -7,7 +7,7 @@ output "cluster_name" {
 }
 
 output "cluster_ca" {
-  value = aws_eks_cluster.eks.certificate_authority[0].data
+  value     = aws_eks_cluster.eks.certificate_authority[0].data
   sensitive = true
 }
 

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -65,7 +65,7 @@ resource "aws_default_security_group" "restrict_default" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = []
   }
 
   egress {


### PR DESCRIPTION
This pull request makes a security improvement to the default security group configuration in the `terraform/vpc.tf` file.

Security improvement:

* [`terraform/vpc.tf`](diffhunk://#diff-2b29c90fc9006dc912e5d16ce27b0dd001e25006e6851ce070fabf362dbfbf10L68-R68): Updated the ingress rule for `aws_default_security_group` to restrict access by changing `cidr_blocks` from allowing all IPs (`["0.0.0.0/0"]`) to an empty list (`[]`). This ensures no inbound traffic is allowed by default.