### PR TITLE
Terraform

### DIFF
--- a/terraform/keys.tf
+++ b/terraform/keys.tf
@@ -1,0 +1,40 @@
+resource "aws_kms_key" "cloudwatch_logs" {
+  description         = "KMS key for CloudWatch Logs"
+  enable_key_rotation = true
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Id      = "key-default-1",
+    Statement = [
+      {
+        Sid    = "Allow root account to manage the key",
+        Effect = "Allow",
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        },
+        Action   = "kms:*",
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow CloudWatch Logs to use the key",
+        Effect = "Allow",
+        Principal = {
+          Service = "logs.${var.region}.amazonaws.com"
+        },
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ],
+        Resource = "*",
+        Condition = {
+          StringEquals = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/vpc/flow-log/eks"
+          }
+        }
+      }
+    ]
+  })
+}

--- a/terraform/roles.tf
+++ b/terraform/roles.tf
@@ -1,0 +1,41 @@
+resource "aws_iam_role" "vpc_flow_log" {
+  name = "eks-vpc-flow-log-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "vpc-flow-logs.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "vpc_flow_log" {
+  name = "eks-vpc-flow-log-policy"
+  role = aws_iam_role.vpc_flow_log.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "${aws_cloudwatch_log_group.vpc_flow_log.arn}"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams"
+        ]
+        Resource = "${aws_cloudwatch_log_group.vpc_flow_log.arn}"
+      }
+    ]
+  })
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -60,21 +60,21 @@ resource "aws_route_table_association" "eks_public" {
 resource "aws_default_security_group" "restrict_default" {
   vpc_id = aws_vpc.eks.id
 
-  ingress {
-    self        = true
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = []
-  }
+  # ingress {
+  #   self        = true
+  #   from_port   = 0
+  #   to_port     = 0
+  #   protocol    = "-1" # All protocols
+  #   cidr_blocks = []
+  # }
 
-  egress {
-    self        = true
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  # egress {
+  #   self        = true
+  #   from_port   = 0
+  #   to_port     = 0
+  #   protocol    = "-1"
+  #   cidr_blocks = ["0.0.0.0/0"]
+  # }
 
   tags = {
     Name = "eks-default-sg"


### PR DESCRIPTION
This pull request introduces several changes to enhance the monitoring and security of the AWS infrastructure for an EKS-based VPC. The most notable updates include the addition of a KMS key for encrypting CloudWatch Logs, IAM roles and policies for VPC flow logs, and the creation of resources for capturing and storing VPC flow logs. Additionally, default security group rules have been commented out for tighter control. Below is a breakdown of the changes grouped by theme:

### Monitoring Enhancements:
* **KMS Key for CloudWatch Logs**: Added a new KMS key resource (`aws_kms_key.cloudwatch_logs`) to encrypt CloudWatch Logs, ensuring compliance with security best practices.
* **CloudWatch Log Group for VPC Flow Logs**: Created a CloudWatch Log Group (`aws_cloudwatch_log_group.vpc_flow_log`) with a retention period of 365 days and linked it to the KMS key for encryption.
* **VPC Flow Logs Resource**: Added a `aws_flow_log.eks` resource to capture all traffic within the VPC and store it in the CloudWatch Log Group.

### IAM Role and Policy Updates:
* **IAM Role for VPC Flow Logs**: Defined a new IAM role (`aws_iam_role.vpc_flow_log`) with an assume role policy allowing the VPC Flow Logs service to assume the role.
* **IAM Policy for VPC Flow Logs**: Attached a policy (`aws_iam_role_policy.vpc_flow_log`) to the IAM role, granting permissions to create log streams and put log events in the CloudWatch Log Group.

### Security Adjustments:
* **Default Security Group Rules**: Commented out ingress and egress rules in the default security group (`aws_default_security_group.restrict_default`) to restrict open access and align with security best practices.