### PR TITLE
Uncomment Terraform resources for S3 bucket state management and logging

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -8,86 +8,86 @@
 #   }
 # }
 
-# resource "aws_s3_bucket" "tf_state" {
-#   # This bucket is used for storing Terraform state files
-#   # checkov:skip=CKV_AWS_144: development bucket, not production
-#   # checkov:skip=CKV2_AWS_62: development bucket, not production
-#   bucket        = "terraform-state-bucket-2727"
-#   force_destroy = true
-#   tags = {
-#     Name = "terraform-state-bucket-2727"
-#   }
-# }
+resource "aws_s3_bucket" "tf_state" {
+  # This bucket is used for storing Terraform state files
+  # checkov:skip=CKV_AWS_144: development bucket, not production
+  # checkov:skip=CKV2_AWS_62: development bucket, not production
+  bucket        = "terraform-state-bucket-2727"
+  force_destroy = true
+  tags = {
+    Name = "terraform-state-bucket-2727"
+  }
+}
 
-# resource "aws_s3_bucket_public_access_block" "tf_state_public_access_block" {
-#   bucket                  = aws_s3_bucket.tf_state.id
-#   block_public_acls       = true
-#   block_public_policy     = true
-#   ignore_public_acls      = true
-#   restrict_public_buckets = true
-# }
+resource "aws_s3_bucket_public_access_block" "tf_state_public_access_block" {
+  bucket                  = aws_s3_bucket.tf_state.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
 
-# resource "aws_s3_bucket_versioning" "tf_state_versioning" {
-#   bucket = aws_s3_bucket.tf_state.id
+resource "aws_s3_bucket_versioning" "tf_state_versioning" {
+  bucket = aws_s3_bucket.tf_state.id
 
-#   versioning_configuration {
-#     status = "Enabled"
-#   }
-# }
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
 
-# resource "aws_s3_bucket_server_side_encryption_configuration" "tf_state_encryption" {
-#   bucket = aws_s3_bucket.tf_state.id
+resource "aws_s3_bucket_server_side_encryption_configuration" "tf_state_encryption" {
+  bucket = aws_s3_bucket.tf_state.id
 
-#   rule {
-#     apply_server_side_encryption_by_default {
-#       kms_master_key_id = aws_kms_key.s3_bucket_key.arn
-#       sse_algorithm     = "aws:kms"
-#     }
-#   }
-# }
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.s3_bucket_key.arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
 
-# resource "aws_s3_bucket_lifecycle_configuration" "tf_state_lifecycle" {
-#   bucket = aws_s3_bucket.tf_state.id
+resource "aws_s3_bucket_lifecycle_configuration" "tf_state_lifecycle" {
+  bucket = aws_s3_bucket.tf_state.id
 
-#   rule {
-#     id     = "expire-old-versions"
-#     status = "Enabled"
+  rule {
+    id     = "expire-old-versions"
+    status = "Enabled"
 
-#     filter {
-#       prefix = "" # Replicate all objects
-#     }
+    filter {
+      prefix = "" # Replicate all objects
+    }
 
-#     noncurrent_version_transition {
-#       noncurrent_days = 30
-#       storage_class   = "STANDARD_IA"
-#     }
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "STANDARD_IA"
+    }
 
-#     noncurrent_version_expiration {
-#       noncurrent_days = 90
-#     }
-#   }
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+  }
 
-#   rule {
-#     id     = "delete-old-objects"
-#     status = "Enabled"
+  rule {
+    id     = "delete-old-objects"
+    status = "Enabled"
 
-#     filter {
-#       prefix = "" # Replicate all objects
-#     }
+    filter {
+      prefix = "" # Replicate all objects
+    }
 
-#     expiration {
-#       days = 365
-#     }
+    expiration {
+      days = 365
+    }
 
-#     abort_incomplete_multipart_upload {
-#       days_after_initiation = 7
-#     }
-#   }
-# }
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
 
-# resource "aws_s3_bucket_logging" "tf_state_logging" {
-#   bucket = aws_s3_bucket.tf_state.id
+resource "aws_s3_bucket_logging" "tf_state_logging" {
+  bucket = aws_s3_bucket.tf_state.id
 
-#   target_bucket = aws_s3_bucket.tf_state.id
-#   target_prefix = "logs/"
-# }
+  target_bucket = aws_s3_bucket.tf_state.id
+  target_prefix = "logs/"
+}


### PR DESCRIPTION
This pull request makes changes to the `terraform/backend.tf` file by uncommenting and re-enabling the configuration for an S3 bucket used to store Terraform state files. This includes restoring the bucket's associated settings such as public access blocking, versioning, encryption, lifecycle rules, and logging.

### Key Changes:

#### S3 Bucket Configuration:
- Restored the `aws_s3_bucket` resource for the Terraform state bucket, including its name, `force_destroy` setting, and tags.

#### Public Access Control:
- Re-enabled the `aws_s3_bucket_public_access_block` resource to prevent public access to the bucket by blocking public ACLs and policies and restricting public buckets.

#### Versioning and Encryption:
- Reinstated the `aws_s3_bucket_versioning` resource to enable versioning on the bucket.
- Reinstated the `aws_s3_bucket_server_side_encryption_configuration` resource to enforce server-side encryption using an AWS KMS key.

#### Lifecycle Management:
- Re-enabled the `aws_s3_bucket_lifecycle_configuration` resource to manage object lifecycle, including transitioning noncurrent versions to infrequent access storage after 30 days and expiring them after 90 days. It also includes rules for deleting old objects and aborting incomplete multipart uploads.

####