### PR TITLE
Terraform

### DIFF
--- a/kube/Dockerfile
+++ b/kube/Dockerfile
@@ -1,24 +1,24 @@
 FROM nginx:alpine
 
 # Create a non-root user and group
-RUN addgroup -S -g 1000 appgroup && \
-    adduser -S -u 1000 -G appgroup appuser
+RUN addgroup -S -g 10001 appgroup && \
+    adduser -S -u 10001 -G appgroup appuser
 
 # Prepare necessary directories
 RUN mkdir -p /var/cache/nginx /var/run /run /usr/share/nginx/html
 
 # Copy static content and config
-COPY --chown=1000:1000 index.html /usr/share/nginx/html/index.html
-COPY --chown=1000:1000 nginx.conf /etc/nginx/nginx.conf
+COPY --chown=10001:10001 index.html /usr/share/nginx/html/index.html
+COPY --chown=10001:10001 nginx.conf /etc/nginx/nginx.conf
 
 # Set correct permissions
-RUN chown -R 1000:1000 /var/cache/nginx /var/run /run /usr/share/nginx/html
+RUN chown -R 10001:10001 /var/cache/nginx /var/run /run /usr/share/nginx/html
 
 # Health check
 HEALTHCHECK --interval=5m --timeout=3s CMD curl -f http://localhost:8080/ || exit 1
 
 # Run as non-root user
-USER 1000:1000
+USER 10001:10001
 
 # Expose non-privileged port
 EXPOSE 8080

--- a/terraform/deploy.tf
+++ b/terraform/deploy.tf
@@ -74,7 +74,7 @@ resource "kubernetes_deployment" "hello_world" {
 
       spec {
         automount_service_account_token = false
-        
+
         security_context {
           run_as_non_root = true
           run_as_user     = 10001

--- a/terraform/deploy.tf
+++ b/terraform/deploy.tf
@@ -54,7 +54,7 @@ resource "kubernetes_deployment" "hello_world" {
   }
 
   spec {
-    replicas                  = 2
+    replicas                  = 3
     revision_history_limit    = 10
     min_ready_seconds         = 5
     progress_deadline_seconds = 300
@@ -73,9 +73,11 @@ resource "kubernetes_deployment" "hello_world" {
       }
 
       spec {
+        automount_service_account_token = false
+        
         security_context {
           run_as_non_root = true
-          run_as_user     = 1000
+          run_as_user     = 10001
         }
 
         volume {
@@ -121,10 +123,13 @@ resource "kubernetes_deployment" "hello_world" {
             }
           }
           security_context {
-            run_as_user                = 1000
+            run_as_user                = 10001
             run_as_non_root            = true
             allow_privilege_escalation = false
             read_only_root_filesystem  = true
+            seccomp_profile {
+              type = "RuntimeDefault"
+            }
             capabilities {
               drop = ["ALL"]
             }

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -9,6 +9,7 @@ data "external" "my_ip" {
 }
 
 resource "aws_eks_cluster" "eks" {
+  # checkov:skip=CKV_AWS_39: Pubic access to the EKS cluster is required for this demo
 
   name     = var.cluster_name
   role_arn = aws_iam_role.eks_cluster.arn

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -9,6 +9,7 @@ data "external" "my_ip" {
 }
 
 resource "aws_eks_cluster" "eks" {
+
   name     = var.cluster_name
   role_arn = aws_iam_role.eks_cluster.arn
 
@@ -42,9 +43,9 @@ resource "aws_eks_node_group" "node_group" {
   subnet_ids      = aws_subnet.eks[*].id
 
   scaling_config {
-    desired_size = 2
-    max_size     = 4
-    min_size     = 1
+    desired_size = 4
+    min_size     = 2
+    max_size     = 6
   }
 
   # instance_types = ["t3.small"]

--- a/terraform/manifests/hello-world-deployment.yaml
+++ b/terraform/manifests/hello-world-deployment.yaml
@@ -21,9 +21,10 @@ spec:
       labels:
         app: hello-world
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+        runAsUser: 10001
       volumes:
         - name: nginx-cache
           emptyDir: {}
@@ -49,10 +50,12 @@ spec:
               cpu: 100m
               memory: 64Mi
           securityContext:
-            runAsUser: 1000
+            runAsUser: 10001
             runAsNonRoot: true
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
             capabilities:
               drop:
                 - ALL

--- a/terraform/manifests/hello-world-deployment.yaml
+++ b/terraform/manifests/hello-world-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     deployment.kubernetes.io/revision: "1"
     description: Hello World Deployment
 spec:
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   minReadySeconds: 5
   progressDeadlineSeconds: 300
@@ -32,7 +32,7 @@ spec:
           emptyDir: {}
       containers:
         - name: hello-world
-          image: 802645170184.dkr.ecr.us-east-1.amazonaws.com/hello-world-demo:1.2.0@652a92910ae9b39bf9f96cdde7496f4b53595976830810ef8125c282a34ad7b8
+          image: 802645170184.dkr.ecr.us-east-1.amazonaws.com/hello-world-demo:1.2.0@sha256:7d29cd1195c0cb64d67f9aa7ed0fd3de723026566679a9354fbadbb19e2450bd
           imagePullPolicy: Always
           ports:
             - containerPort: 80

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -60,7 +60,7 @@ variable "image_tag" {
 
 variable "image_digest" {
   description = "Digest of the Docker image to be used in the deployment"
-  default     = "sha256:652a92910ae9b39bf9f96cdde7496f4b53595976830810ef8125c282a34ad7b8"
+  default     = "sha256:7d29cd1195c0cb64d67f9aa7ed0fd3de723026566679a9354fbadbb19e2450bd"
   type        = string
 
 }

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -19,12 +19,11 @@ resource "aws_cloudwatch_log_group" "vpc_flow_log" {
 }
 
 resource "aws_flow_log" "eks" {
+  iam_role_arn         = aws_iam_role.vpc_flow_log.arn
   log_destination      = aws_cloudwatch_log_group.vpc_flow_log.arn
   log_destination_type = "cloud-watch-logs"
   traffic_type         = "ALL"
   vpc_id               = aws_vpc.eks.id
-
-  iam_role_arn = aws_iam_role.vpc_flow_log.arn
 }
 
 # Internet Gateway


### PR DESCRIPTION
This pull request includes updates to improve security, scalability, and maintainability across the Docker configuration, Kubernetes manifests, and Terraform infrastructure. Key changes include updating user IDs for non-root execution, increasing resource scaling limits, and enhancing security configurations.

### Security Improvements:
* [`kube/Dockerfile`](diffhunk://#diff-aabafa62193c77afac0a2f4f9af4ec69fa580f0239e7c2cfeefb935c2a8f95e9L4-R21): Updated the non-root user and group IDs from `1000` to `10001` for better isolation and alignment with security standards. Adjusted ownership and permissions accordingly.
* `terraform/deploy.tf` and `terraform/manifests/hello-world-deployment.yaml`: Updated `runAsUser` to `10001` and added `seccompProfile` with `RuntimeDefault` for enhanced container security. Disabled `automount_service_account_token` to mitigate unnecessary token exposure. [[1]](diffhunk://#diff-a81210900ae1af695e8b57250da157be1af3451945184d56764bcc10e1249e51R76-R80) [[2]](diffhunk://#diff-a81210900ae1af695e8b57250da157be1af3451945184d56764bcc10e1249e51L124-R132) [[3]](diffhunk://#diff-fd1cc9cc755157be518b62e9f0919583d8aae416223691f88766dbaf8c6bef06R24-R35) [[4]](diffhunk://#diff-fd1cc9cc755157be518b62e9f0919583d8aae416223691f88766dbaf8c6bef06L52-R58)

### Scalability Enhancements:
* `terraform/deploy.tf` and `terraform/manifests/hello-world-deployment.yaml`: Increased the number of replicas for the `hello-world` deployment from `2` to `3` to improve availability. [[1]](diffhunk://#diff-a81210900ae1af695e8b57250da157be1af3451945184d56764bcc10e1249e51L57-R57) [[2]](diffhunk://#diff-fd1cc9cc755157be518b62e9f0919583d8aae416223691f88766dbaf8c6bef06L12-R12)
* [`terraform/eks.tf`](diffhunk://#diff-1f70d47d5bfebbd54008b1d2e68a8232a0e525d11ea372fe11ebc7ef913e43b1L45-R49): Adjusted the EKS node group scaling configuration to support a desired size of `4` nodes, with a minimum of `2` and a maximum of `6`.

### Maintainability and Configuration Updates:
* `terraform/variables.tf` and `terraform/manifests/hello-world-deployment.yaml`: Updated the Docker image digest to a new version (`sha256:7d29cd1195c0cb64d67f9aa7ed0fd3de723026566679a9354fbadbb19e2450bd`) for consistency across the deployment. [[1]](diffhunk://#diff-fd1cc9cc755157be518b62e9f0919583d8aae416223691f88766dbaf8c6bef06R24-R35) [[2]](diffhunk://#diff-b25e8cb262b29f5005a96d0c4a06a3deb77698fa6e11e4f43b21f6f4ad0f45e4L63-R63)
* [`terraform/eks.tf`](diffhunk://#diff-1f70d47d5bfebbd54008b1d2e68a8232a0e525d11ea372fe11ebc7ef913e43b1R12-R13): Added a `checkov` comment to skip a security check for public EKS access, noting its necessity for the demo environment.
* [`terraform/vpc.tf`](diffhunk://#diff-2b29c90fc9006dc912e5d16ce27b0dd001e25006e6851ce070fabf362dbfbf10R22-L27): Fixed the placement of the `iam_role_arn` attribute in the `aws_flow_log` resource for better readability and compliance with Terraform conventions.