### PR TITLE
Fix output variable name for ECR image in outputs.tf

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -24,7 +24,7 @@ output "hello_world_service_endpoint" {
   value       = "http://${kubernetes_service.hello_world_service.status[0].load_balancer[0].ingress[0].hostname}"
 }
 
-output "ecrimage" {
+output "ecr_image" {
   description = "Docker image to be used in the deployment"
   value       = kubernetes_deployment.hello_world.spec[0].template[0].spec[0].container[0].image
 }


### PR DESCRIPTION
This pull request includes a minor change to the `terraform/outputs.tf` file, improving consistency in naming conventions by renaming an output variable.

* **Naming convention improvement**:
  * Renamed the `output` block from `ecrimage` to `ecr_image` for better readability and adherence to naming conventions. (`terraform/outputs.tf`, [terraform/outputs.tfL27-R27](diffhunk://#diff-39c11374cc25633f69e49ef1485fa8d4dfd4c33cde3027c8c20a2b84346ebf7cL27-R27))