### PR TITLE
Add check and creation for tfstate S3 bucket in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -31,3 +31,24 @@ if ! command -v jq --version &> /dev/null; then
 else
     echo "jq is already installed."
 fi
+
+# Check if tfstate s3 bucket exists, if not create it
+BUCKET="terraform-state-bucket-2727"
+REGION="us-east-1"
+
+if ! aws s3api head-bucket --bucket "$BUCKET" --region "$REGION" > /dev/null 2>&1; then
+  echo "Creating S3 bucket: $BUCKET"
+  if [ "$REGION" = "us-east-1" ]; then
+    aws s3api create-bucket \
+      --bucket "$BUCKET" \
+      --region "$REGION" \
+      --create-bucket-configuration LocationConstraint="$REGION" \
+      > /dev/null
+  else
+    aws s3api create-bucket \
+      --bucket "$BUCKET" \
+      --region "$REGION" \
+      --create-bucket-configuration LocationConstraint="$REGION" \
+      > /dev/null
+  fi
+fi


### PR DESCRIPTION
This pull request introduces a new script in the `.envrc` file to automate the creation of an S3 bucket for Terraform state if it does not already exist. This change enhances the setup process by ensuring the required bucket is available without manual intervention.

Key changes:

### Infrastructure setup improvements:
* Added a script to check for the existence of an S3 bucket (`terraform-state-bucket-2727`) in the `us-east-1` region. If the bucket does not exist, it is automatically created using the AWS CLI. (`[.envrcR34-R54](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430R34-R54)`)