### PR TITLE
Refactor tf-run target in Makefile to streamline Terraform task execu…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ TF_DIR=terraform
 
 default: check-aws init-bucket
 
-tf-run: terraform-format terraform-init terraform-validate terraform-plan
+tf-run: tf-format tf-init tf-validate tf-plan
+	@echo "✅ Terraform tasks completed successfully."
+	@echo "🚀 To apply changes, run 'make tf-apply'."
 	@echo "🔄 Running Terraform tasks..."
 
 check-aws:


### PR DESCRIPTION
This pull request updates the `Makefile` to improve the naming consistency of Terraform-related commands and enhance user feedback during execution.

### Improvements to naming consistency:
* Renamed targets `terraform-format`, `terraform-init`, `terraform-validate`, and `terraform-plan` to `tf-format`, `tf-init`, `tf-validate`, and `tf-plan` for consistency with other target names. 

### Enhancements to user feedback:
* Added success and guidance messages to the `tf-run` target, including a confirmation message (`✅ Terraform tasks completed successfully.`) and a prompt to apply changes (`🚀 To apply changes, run 'make tf-apply'.`). 