### PR TITLE
Terraform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,16 @@ tf-destroy:
 	cd $(TF_DIR) && terraform destroy
 	@echo "✅ Terraform resources destroyed."
 
+tf-output:
+	cd $(TF_DIR) && terraform output
+	@echo "✅ Terraform outputs displayed."
+	@echo "🔍 To view specific output, run 'terraform output <output_name>'."
+
+tf-delete-ecr-repo:
+	@echo "⚠️  Deleting ECR repository: hello-world-demo"
+	@aws ecr delete-repository --repository-name hello-world-demo --region $(AWS_REGION) --force
+	@echo "✅ ECR repository 'hello-world-demo' deleted."
+
 clean: check-aws
 	@echo "⚠️  WARNING: This will delete the S3 bucket: $(S3_BUCKET)"
 	@read -p "Are you sure? (y/N): " confirm; \

--- a/kube/index.html
+++ b/kube/index.html
@@ -2,6 +2,18 @@
 <html>
     <head>
         <title>Hello World</title>
+        <style>
+            body {
+                background-color: #181a1b;
+                color: #f5f6fa;
+                font-family: Arial, sans-serif;
+            }
+            h1 {
+                color: #8be9fd;
+                text-align: center;
+                margin-top: 20vh;
+            }
+        </style>
     </head>
     <body>
         <h1>&#128640; Hello from Kubernetes! &#128640;</h1>

--- a/terraform/local.tf
+++ b/terraform/local.tf
@@ -23,7 +23,7 @@ resource "null_resource" "image_build" {
   }
 
   provisioner "local-exec" {
-    command     = "../scripts/image.sh"
+    command     = "${path.module}./scripts/image.sh"
     interpreter = ["bash", "-c"]
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -60,7 +60,7 @@ variable "image_tag" {
 
 variable "image_digest" {
   description = "Digest of the Docker image to be used in the deployment"
-  default     = "sha256:7d29cd1195c0cb64d67f9aa7ed0fd3de723026566679a9354fbadbb19e2450bd"
+  default     = "sha256:819eb6ffcd649e3bb25198f211955256b03cfd55f07976e270cd204c814a3eef"
   type        = string
 
 }


### PR DESCRIPTION
This pull request introduces several updates across different files, including new Makefile targets, styling changes for a Kubernetes HTML page, and adjustments to Terraform configurations. Below is a summary of the most important changes grouped by theme.

### Makefile Enhancements:

* Added `tf-output` target to display Terraform outputs with instructions for viewing specific outputs.
* Added `tf-delete-ecr-repo` target to delete the `hello-world-demo` ECR repository using AWS CLI.

### Kubernetes HTML Styling:

* Updated `kube/index.html` to include a dark-themed style with customized colors for the background, text, and heading.

### Terraform Configuration Updates:

* Modified the `command` in `null_resource.image_build` to use `${path.module}` for a relative script path in `terraform/local.tf`.
* Updated the default value of the `image_digest` variable in `terraform/variables.tf` to a new SHA256 hash.