### PR TITLE
Terraform

### DIFF
--- a/kube/index.html
+++ b/kube/index.html
@@ -13,9 +13,97 @@
                 text-align: center;
                 margin-top: 20vh;
             }
+            canvas#confetti-canvas {
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 100vw;
+                height: 100vh;
+                pointer-events: none;
+                z-index: 9999;
+            }
         </style>
     </head>
     <body>
+        <canvas id="confetti-canvas"></canvas>
         <h1>&#128640; Hello from Kubernetes! &#128640;</h1>
+        <script>
+            // Simple confetti effect
+            const canvas = document.getElementById('confetti-canvas');
+            const ctx = canvas.getContext('2d');
+            let W = window.innerWidth;
+            let H = window.innerHeight;
+            canvas.width = W;
+            canvas.height = H;
+
+            const confettiColors = ['#f9ca24', '#e17055', '#00b894', '#0984e3', '#fd79a8', '#fdcb6e', '#00cec9'];
+            const confettiCount = 120;
+            const confetti = [];
+
+            function randomInt(min, max) {
+                return Math.floor(Math.random() * (max - min + 1)) + min;
+            }
+
+            function Confetto() {
+                this.x = randomInt(0, W);
+                this.y = randomInt(-H, 0);
+                this.r = randomInt(5, 10);
+                this.d = randomInt(2, 6);
+                this.color = confettiColors[randomInt(0, confettiColors.length - 1)];
+                this.tilt = randomInt(-10, 10);
+                this.tiltAngleIncremental = (Math.random() * 0.07) + .05;
+                this.tiltAngle = 0;
+
+                this.draw = function() {
+                    ctx.beginPath();
+                    ctx.lineWidth = this.r;
+                    ctx.strokeStyle = this.color;
+                    ctx.moveTo(this.x + this.tilt + (this.r / 3), this.y);
+                    ctx.lineTo(this.x + this.tilt, this.y + this.tilt + this.d);
+                    ctx.stroke();
+                }
+            }
+
+            function drawConfetti() {
+                ctx.clearRect(0, 0, W, H);
+                for (let i = 0; i < confetti.length; i++) {
+                    confetti[i].draw();
+                }
+                updateConfetti();
+            }
+
+            function updateConfetti() {
+                for (let i = 0; i < confetti.length; i++) {
+                    confetti[i].y += (Math.cos(confetti[i].d) + 3 + confetti[i].d / 2) / 2;
+                    confetti[i].x += Math.sin(0.01 * confetti[i].y);
+                    confetti[i].tiltAngle += confetti[i].tiltAngleIncremental;
+                    confetti[i].tilt = Math.sin(confetti[i].tiltAngle) * 15;
+
+                    if (confetti[i].y > H) {
+                        confetti[i].x = randomInt(0, W);
+                        confetti[i].y = randomInt(-20, 0);
+                        confetti[i].tilt = randomInt(-10, 10);
+                    }
+                }
+            }
+
+            function resizeCanvas() {
+                W = window.innerWidth;
+                H = window.innerHeight;
+                canvas.width = W;
+                canvas.height = H;
+            }
+
+            window.addEventListener('resize', resizeCanvas);
+
+            for (let i = 0; i < confettiCount; i++) {
+                confetti.push(new Confetto());
+            }
+
+            (function animateConfetti() {
+                drawConfetti();
+                requestAnimationFrame(animateConfetti);
+            })();
+        </script>
     </body>
 </html>

--- a/scripts/image.sh
+++ b/scripts/image.sh
@@ -6,8 +6,8 @@
 AWS_REGION="us-east-1"
 AWS_ACCOUNT_ID="802645170184"
 REPO_NAME="hello-world-demo"
-IMAGE_TAG="1.2.0"
-LOCAL_IMAGE_NAME="hello-world"
+IMAGE_TAG="1.2.2"
+LOCAL_IMAGE_NAME="hello-world-demo"
 PLATFORM_ARCH="linux/arm64"
 # ---------------------------------
 

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -54,7 +54,7 @@ resource "aws_eks_node_group" "node_group" {
   # disk_size      = 20
   # ami_type       = "AL2023_x86_64_STANDARD"
 
-  instance_types = ["t4g.micro"]
+  instance_types = [var.instance_type]
   capacity_type  = "ON_DEMAND"
   disk_size      = 20
   ami_type       = "AL2023_ARM_64_STANDARD"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -42,7 +42,7 @@ variable "aws_account_id" {
 
 variable "instance_type" {
   description = "EC2 instance type for the EKS node group"
-  default     = "t3.small"
+  default     = "t4g.micro"
   type        = string
 }
 
@@ -54,13 +54,13 @@ variable "repo_name" {
 
 variable "image_tag" {
   description = "Docker image tag"
-  default     = "1.2.0"
+  default     = "1.2.2"
   type        = string
 }
 
 variable "image_digest" {
   description = "Digest of the Docker image to be used in the deployment"
-  default     = "sha256:819eb6ffcd649e3bb25198f211955256b03cfd55f07976e270cd204c814a3eef"
+  default     = "sha256:4282cb9a2f11afbc058a0cbdaf906831630e974aa8da9c0c89d9ffcb127fc4e5"
   type        = string
 
 }


### PR DESCRIPTION
This pull request introduces a confetti animation effect to the Kubernetes demo page, updates Docker image configurations, and makes EKS node group settings more flexible. Below are the key changes grouped by theme:

### Frontend Enhancement
* Added a confetti animation to the Kubernetes demo page by including a `<canvas>` element and corresponding JavaScript for rendering the effect (`kube/index.html`).

### Docker Image Updates
* Updated the Docker image tag from `1.2.0` to `1.2.2` and changed the local image name to `hello-world-demo` in the `scripts/image.sh` file.
* Updated the default Docker image tag and digest in `terraform/variables.tf` to reflect the new image version and its corresponding SHA256 digest.

### EKS Node Group Configuration
* Made the EKS node group instance type configurable by replacing the hardcoded `t4g.micro` instance type with a Terraform variable (`terraform/eks.tf`).
* Changed the default value of the `instance_type` variable from `t3.small` to `t4g.micro` in `terraform/variables.tf` to align with the updated configuration.