### PR TITLE
Add rolling update strategy to hello-world deployment

### DIFF
--- a/manifests/hello-world-deployment.yaml
+++ b/manifests/hello-world-deployment.yaml
@@ -13,6 +13,11 @@ spec:
   revisionHistoryLimit: 10
   minReadySeconds: 5
   progressDeadlineSeconds: 300
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
   selector:
     matchLabels:
       app: hello-world


### PR DESCRIPTION
This pull request introduces a deployment strategy configuration to the `hello-world` deployment manifest. The change specifies a rolling update strategy to improve the deployment process.

Key change:

* [`manifests/hello-world-deployment.yaml`](diffhunk://#diff-2ced74aaf2e35b96a82c4619063f89eb41837ab6e70bc36d51051c972b8e13c8R16-R20): Added a `strategy` field with `type: RollingUpdate` and configured `rollingUpdate` parameters (`maxUnavailable: 25%` and `maxSurge: 25%`) to enable controlled rolling updates.