### PR TITLE
Terraform

### DIFF
--- a/scripts/cleanup_lb.sh
+++ b/scripts/cleanup_lb.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+export AWS_PAGER=""
+
+set -e
+
+NAMESPACE=$1
+REGION="us-east-1"
+VPC_NAME="eks-vpc"
+
+echo "⚠️ Cleaning up Kubernetes services in namespace '$NAMESPACE'..."
+kubectl patch svc prometheus-prometheus -n "$NAMESPACE" -p '{"metadata":{"finalizers":null}}' --type=merge || true
+kubectl patch svc prometheus-grafana -n "$NAMESPACE" -p '{"metadata":{"finalizers":null}}' --type=merge || true
+kubectl patch svc hello-world-service -n hello-world-ns -p '{"metadata":{"finalizers":null}}' --type=merge || true
+# kubectl delete svc --all -n "$NAMESPACE" --ignore-not-found || true
+
+echo "⏱️ Sleeping for 10 seconds to ensure services are deleted..."
+sleep 10
+
+echo "🧨 Deleting Prometheus Helm release..."
+helm uninstall prometheus -n "$NAMESPACE" || true
+
+echo "🔍 Locating VPC with tag Name=$VPC_NAME in region $REGION..."
+VPC_ID=$(aws ec2 describe-vpcs \
+  --region "$REGION" \
+  --filters "Name=tag:Name,Values=$VPC_NAME" \
+  --query "Vpcs[0].VpcId" \
+  --output text)
+
+if [[ "$VPC_ID" == "None" || -z "$VPC_ID" ]]; then
+  echo "❌ VPC named '$VPC_NAME' not found in region '$REGION'. Exiting."
+  exit 1
+fi
+
+echo "✅ Found VPC: $VPC_ID"
+
+### ALB / NLB
+echo "🧨 Deleting ALB/NLBs in VPC: $VPC_ID"
+aws elbv2 describe-load-balancers \
+  --region "$REGION" \
+  --query "LoadBalancers[?VpcId=='$VPC_ID'].LoadBalancerArn" \
+  --output text | \
+xargs -r -n 1 aws elbv2 delete-load-balancer --region "$REGION" --load-balancer-arn
+
+### Classic ELB
+echo "🧨 Deleting Classic ELBs in VPC: $VPC_ID"
+aws elb describe-load-balancers \
+  --region "$REGION" \
+  --query "LoadBalancerDescriptions[?VPCId=='$VPC_ID'].LoadBalancerName" \
+  --output text | \
+xargs -r -n 1 aws elb delete-load-balancer --region "$REGION" --load-balancer-name
+
+echo "✅ All scoped Load Balancers have been deleted from VPC '$VPC_NAME' ($VPC_ID)."

--- a/scripts/cleanup_sg.sh
+++ b/scripts/cleanup_sg.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+export AWS_PAGER=""
+
+set -euo pipefail
+
+# Required settings
+REGION="us-east-1"
+VPC_NAME="eks-vpc"
+
+echo "🔍 Locating VPC with tag Name=$VPC_NAME in region $REGION..."
+VPC_ID=$(aws ec2 describe-vpcs \
+  --region "$REGION" \
+  --filters "Name=tag:Name,Values=$VPC_NAME" \
+  --query "Vpcs[0].VpcId" \
+  --output text)
+
+if [[ "$VPC_ID" == "None" || -z "$VPC_ID" ]]; then
+  echo "❌ VPC named '$VPC_NAME' not found in region '$REGION'. Exiting."
+  exit 1
+fi
+
+echo "✅ Found VPC: $VPC_ID"
+
+echo "🔍 Fetching all security groups in VPC $VPC_NAME..."
+
+# Get security group IDs, one per line
+SG_IDS=$(aws ec2 describe-security-groups \
+  --region "$REGION" \
+  --filters Name=vpc-id,Values="$VPC_ID" \
+  --query "SecurityGroups[*].GroupId" \
+  --output text | tr '\t' '\n')
+
+echo "✅ Found $(echo "$SG_IDS" | wc -l) SGs"
+echo ""
+
+# Loop through each SG
+while IFS= read -r sg; do
+  [[ -z "$sg" ]] && continue
+
+  # Skip default SG
+  GROUP_NAME=$(aws ec2 describe-security-groups \
+    --region "$REGION" \
+    --group-ids "$sg" \
+    --query 'SecurityGroups[0].GroupName' \
+    --output text)
+
+  if [[ "$GROUP_NAME" == "default" ]]; then
+    echo "⚠️  Skipping default SG: $sg"
+    continue
+  fi
+
+  echo -n "🔍 Checking $sg ($GROUP_NAME)... "
+
+  ENIS=$(aws ec2 describe-network-interfaces \
+    --region "$REGION" \
+    --filters Name=group-id,Values="$sg" \
+    --query "NetworkInterfaces[*].NetworkInterfaceId" \
+    --output text)
+
+  if [[ -z "$ENIS" ]]; then
+    echo -n "unused → deleting... "
+    if aws ec2 delete-security-group --region "$REGION" --group-id "$sg" 2>/tmp/sg-delete-error; then
+      echo "✅ deleted"
+    else
+      ERROR_MSG=$(cat /tmp/sg-delete-error)
+      if echo "$ERROR_MSG" | grep -q "DependencyViolation"; then
+        echo "⚠️  dependency violation → skipped"
+      else
+        echo "❌ unexpected error:"
+        echo "$ERROR_MSG"
+      fi
+    fi
+  else
+    echo "still in use → skipping"
+  fi
+done <<< "$SG_IDS"
+
+echo ""
+echo "✅ Cleanup completed."

--- a/scripts/delete_services.sh
+++ b/scripts/delete_services.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-NAMESPACE=$1
-
-echo "⚠️  Deleting LoadBalancer services in namespace: $NAMESPACE..."
-kubectl delete svc --all -n "$NAMESPACE" --ignore-not-found
-
-echo "✅  Services deleted."

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -12,9 +12,12 @@ data "external" "my_ip" {
 
 resource "aws_eks_cluster" "eks" {
   # checkov:skip=CKV_AWS_39: Pubic access to the EKS cluster is required for this demo
-  depends_on = [aws_vpc.eks]
-  name       = var.cluster_name
-  role_arn   = aws_iam_role.eks_cluster.arn
+  depends_on = [
+    aws_vpc.eks,
+    null_resource.cleanup_sg
+  ]
+  name     = var.cluster_name
+  role_arn = aws_iam_role.eks_cluster.arn
 
   vpc_config {
     subnet_ids              = aws_subnet.public[*].id

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -28,7 +28,7 @@ resource "null_resource" "image_build" {
   }
 }
 
-resource "null_resource" "pre_destroy_cleanup" {
+resource "null_resource" "cleanup_lb" {
   depends_on = [
     helm_release.prometheus,
     aws_eks_node_group.node_group,
@@ -42,7 +42,7 @@ resource "null_resource" "pre_destroy_cleanup" {
   ]
   provisioner "local-exec" {
     when        = destroy
-    command     = "../scripts/delete_services.sh monitoring-ns"
+    command     = "../scripts/cleanup_lb.sh monitoring-ns"
     interpreter = ["bash", "-c"]
   }
 
@@ -51,4 +51,15 @@ resource "null_resource" "pre_destroy_cleanup" {
   }
 }
 
+resource "null_resource" "cleanup_sg" {
+  depends_on = []
+  provisioner "local-exec" {
+    when        = destroy
+    command     = "../scripts/cleanup_sg.sh"
+    interpreter = ["bash", "-c"]
+  }
 
+  triggers = {
+    always_run = timestamp()
+  }
+}


### PR DESCRIPTION
This pull request introduces improvements to the cleanup process for AWS resources associated with the EKS cluster, focusing on automating the removal of load balancers and security groups during infrastructure teardown. It replaces the previous service deletion script with more comprehensive scripts and updates Terraform resources to ensure proper dependency handling and sequencing of cleanup operations.

**Infrastructure Cleanup Enhancements**

* Added `scripts/cleanup_lb.sh` to automate the removal of Kubernetes services, Helm releases, and AWS load balancers (ALB, NLB, and Classic ELB) associated with the cluster's VPC.
* Added `scripts/cleanup_sg.sh` to identify and delete unused security groups in the cluster's VPC, skipping the default group and handling dependency violations gracefully.

**Terraform Resource Updates**

* Replaced the `null_resource` for pre-destroy cleanup to use the new `cleanup_lb.sh` script instead of the old service deletion script, ensuring load balancers are deleted during teardown.
* Introduced a new `null_resource.cleanup_sg` to run the security group cleanup script during destroy, with a trigger to ensure execution.
* Updated `aws_eks_cluster.eks` resource dependencies to include `null_resource.cleanup_sg`, ensuring that security group cleanup is completed before cluster deletion.

**Deprecation**

* Removed the obsolete `scripts/delete_services.sh` script, consolidating service and load balancer cleanup into the new scripts.