### PR TITLE
Vault

### DIFF
--- a/terraform/helm.tf
+++ b/terraform/helm.tf
@@ -39,7 +39,7 @@ resource "helm_release" "prometheus" {
 
   set {
     name  = "prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues"
-    value = false
+    value = true
   }
 
   # set {
@@ -60,24 +60,6 @@ resource "helm_release" "prometheus" {
   set {
     name  = "grafana.service.port"
     value = "80"
-  }
-}
-
-resource "null_resource" "prometheus_port_forward" {
-  depends_on = [helm_release.prometheus]
-
-  provisioner "local-exec" {
-    command = <<EOT
-      echo "Starting Prometheus port-forward..."
-      kubectl port-forward svc/prometheus-grafana 3000:80 -n monitoring-ns >/tmp/vault-pf.log 2>&1 &
-      kubectl port-forward svc/prometheus-node-exporter 9100:9100 -n monitoring-ns >/tmp/vault-pf.log 2>&1 &
-      echo "Grafana UI should be available at http://localhost:3000/ui"
-      echo "Node Exporter UI should be available at http://localhost:9100/"
-      echo "To stop port-forward, kill the background process:"
-      echo "  pkill -f 'kubectl port-forward svc/prometheus-grafana -n monitoring-ns 3000:80'"
-      echo "  pkill -f 'kubectl port-forward svc/prometheus-node-exporter -n monitoring-ns 9100:9100'"
-    EOT
-    # Keep this running during apply, or run detached (this is a simple fire-and-forget)
   }
 }
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,7 +1,7 @@
 resource "null_resource" "configure_kubectl" {
   depends_on = [aws_eks_cluster.eks]
 
-  triggers = {cluster_name = aws_eks_cluster.eks.id}
+  triggers = { cluster_name = aws_eks_cluster.eks.id }
 
   provisioner "local-exec" {
     command     = <<EOF


### PR DESCRIPTION
This pull request introduces significant improvements to the Vault deployment and management process in Terraform, as well as a minor adjustment to the Prometheus Helm release configuration. The main focus is on automating Vault initialization, unsealing, and secure handling of Kubernetes kubeconfig using Vault as a secrets store. Additionally, it removes the Prometheus port-forwarding resource to streamline the setup.

**Vault deployment and automation enhancements:**

* Added multiple high-availability (`HA`) and injector configuration options to the `helm_release` for Vault, enabling HA mode with Consul backend, UI, and injector features. Also increased Helm release timeout and added explicit dependencies to ensure correct resource creation order. (`terraform/vault.tf`)
* Automated Vault initialization and unsealing with a new `null_resource` that checks if Vault is already initialized, performs initialization if needed, unseals Vault, and stores the root token locally. (`terraform/vault.tf`)
* Implemented secure backup and storage of the Kubernetes kubeconfig in Vault via a port-forwarded connection, including backup of the current config and use of AWS CLI to generate a fresh kubeconfig. (`terraform/vault.tf`)
* Added logic to retrieve and validate the kubeconfig from Vault, backing up the existing config and replacing it only if the retrieved version is valid. (`terraform/vault.tf`)

**Prometheus configuration changes:**

* Changed `prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues` to `true` in the Helm release, which affects how ServiceMonitors are selected. (`terraform/helm.tf`)
* Removed the `null_resource` for Prometheus port-forwarding, simplifying the deployment and removing local port-forward automation for Grafana and Node Exporter. (`terraform/helm.tf`)