### PR TITLE
Terraform

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,31 @@
 #!/usr/bin/env bash
 
+
+if [ -f ~/.aws/config ]; then
+  echo "AWS config file already exists."
+else
+mkdir -p ~/.aws
+  cat > ~/.aws/config <<'EOF'
+[default]
+region = us-east-1
+output = json
+
+[profile prom_infradmin]
+region = us-east-1
+output = json
+#credential_process = aws-pass-creds
+EOF
+echo "AWS config file created at ~/.aws/config."
+fi
+
+AWS_ACCESS_KEY_ID=$(pass aws/main/aws_access_key_id)
+export AWS_ACCESS_KEY_ID
+
+AWS_SECRET_ACCESS_KEY=$(pass aws/main/aws_secret_access_key)
+export AWS_SECRET_ACCESS_KEY
+
+export VAULT_ADDR='http://127.0.0.1:8200'
+
 # Detect OS type
 OS_TYPE="$(uname -s)"
 

--- a/scripts/cleanup_lb.sh
+++ b/scripts/cleanup_lb.sh
@@ -7,9 +7,9 @@ NAMESPACE=$1
 REGION="us-east-1"
 VPC_NAME="eks-vpc"
 
-echo "⚠️ Cleaning up Kubernetes services in namespace '$NAMESPACE'..."
-kubectl patch svc prometheus-prometheus -n "$NAMESPACE" -p '{"metadata":{"finalizers":null}}' --type=merge || true
-kubectl patch svc prometheus-grafana -n "$NAMESPACE" -p '{"metadata":{"finalizers":null}}' --type=merge || true
+echo "⚠️ Cleaning up Kubernetes services..."
+# kubectl patch svc prometheus-prometheus -n "$NAMESPACE" -p '{"metadata":{"finalizers":null}}' --type=merge || true
+# kubectl patch svc prometheus-grafana -n "$NAMESPACE" -p '{"metadata":{"finalizers":null}}' --type=merge || true
 kubectl patch svc hello-world-service -n hello-world-ns -p '{"metadata":{"finalizers":null}}' --type=merge || true
 # kubectl delete svc --all -n "$NAMESPACE" --ignore-not-found || true
 
@@ -17,7 +17,7 @@ echo "⏱️ Sleeping for 10 seconds to ensure services are deleted..."
 sleep 10
 
 echo "🧨 Deleting Prometheus Helm release..."
-helm uninstall prometheus -n "$NAMESPACE" || true
+helm uninstall prometheus -n monitoring-ns || true
 
 echo "🔍 Locating VPC with tag Name=$VPC_NAME in region $REGION..."
 VPC_ID=$(aws ec2 describe-vpcs \

--- a/scripts/fwd-services.sh
+++ b/scripts/fwd-services.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Forward ports for services
+kubectl port-forward -n vault-ns svc/vault 8200:8200 &>/dev/null &
+kubectl port-forward -n monitoring-ns svc/prometheus-prometheus-node-exporter 9100:9100 &>/dev/null &
+kubectl port-forward -n monitoring-ns svc/prometheus-grafana 3000:80 &>/dev/null &
+kubectl port-forward -n monitoring-ns svc/prometheus-kube-prometheus-prometheus 9090:9090 &>/dev/null &

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,9 +1,4 @@
-provider "aws" {
-  shared_credentials_files = ["$HOME/.aws/credentials"]
-  shared_config_files      = ["$HOME/.aws/config"]
-  profile                  = "prom_infradmin"
-  region                   = "us-east-1"
-}
+provider "aws" {}
 
 provider "kubernetes" {
   host                   = aws_eks_cluster.eks.endpoint
@@ -16,6 +11,5 @@ provider "helm" {
     host                   = aws_eks_cluster.eks.endpoint
     cluster_ca_certificate = base64decode(aws_eks_cluster.eks.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.eks.token
-    config_path            = "~/.kube/config"
   }
 }

--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -205,7 +205,8 @@ resource "null_resource" "vault_retrieve_kubeconfig" {
       fi
 
       echo "Stopping port-forward..."
-      kill $PF_PID
+      kill $PF_PID || true
+      pkill -f 'kubectl port-forward svc/vault -n vault-ns 8200:8200' || true
     EOT
   }
 }


### PR DESCRIPTION
This pull request introduces improvements to local development and infrastructure automation, mainly focusing on AWS credential management, Kubernetes service port forwarding, and Terraform provider configuration. The changes streamline environment setup, make service access more convenient, and simplify Terraform provider usage.

**Environment and AWS credential setup:**
* [`.envrc`](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430R3-R28): Automates creation of the AWS config file if it doesn't exist, sets up default and `prom_infradmin` profiles, and exports AWS credentials and Vault address from the password manager for local development.

**Kubernetes service management and port forwarding:**
* [`scripts/fwd-services.sh`](diffhunk://#diff-37ee01ffed238593a73b552c3dfe8fd6abb9c502c7257499d9361464b8724adeR1-R7): Adds a new script to forward local ports to key services (`vault`, `prometheus`, `grafana`, and `node-exporter`), making it easier to access these services during development.
* [`scripts/cleanup_lb.sh`](diffhunk://#diff-9c66e1828a2294ae41171d85623fa4eb9c659b13bb45b9c339b8d712e5ff2f97L10-R20): Updates the cleanup script to comment out Prometheus and Grafana service patches for a specific namespace and instead focuses on the `hello-world-service` and uninstalling Prometheus from `monitoring-ns`.

**Terraform provider configuration:**
* [`terraform/providers.tf`](diffhunk://#diff-832814fa1c0667ba9deaf8d383b5c47d12158b43b25f78eb1363418b0e83cc46L1-R1): Simplifies the AWS provider block by removing explicit credential and config file references, relying on environment variables for authentication. Also removes the explicit `config_path` from the Kubernetes provider configuration. [[1]](diffhunk://#diff-832814fa1c0667ba9deaf8d383b5c47d12158b43b25f78eb1363418b0e83cc46L1-R1) [[2]](diffhunk://#diff-832814fa1c0667ba9deaf8d383b5c47d12158b43b25f78eb1363418b0e83cc46L19)

**Script robustness:**
* [`terraform/vault.tf`](diffhunk://#diff-0c32cd254aedd0688fa82d76acaf18f85700e6244b99c4746b6bfea4767b5e81L208-R209): Improves the cleanup step in the Vault kubeconfig retrieval by adding a fallback to kill any lingering port-forward processes, making the script more reliable.