### PR TITLE
Comment out sensitive token exports and cleanup commands in vault ini…

### DIFF
--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -122,7 +122,7 @@ resource "null_resource" "vault_init" {
         echo "Unsealing Vault..."
         kubectl exec -n vault-ns vault-0 -- vault operator unseal "$VAULT_UNSEAL_KEY"
 
-        echo "$VAULT_ROOT_TOKEN" > ~/.vault-token
+        # echo "$VAULT_ROOT_TOKEN" > ~/.vault-token
       fi
     EOT
   }
@@ -146,7 +146,7 @@ resource "null_resource" "vault_store_kubeconfig" {
       done
 
       export VAULT_ADDR='http://127.0.0.1:8200'
-      export VAULT_TOKEN=$(cat ~/.vault-token)
+      # export VAULT_TOKEN=$(cat ~/.vault-token)
 
       echo "Backing up current kubeconfig to ~/.kube/config.bak"
       mkdir -p ~/.kube
@@ -161,7 +161,8 @@ resource "null_resource" "vault_store_kubeconfig" {
       cat ~/.kube/config | vault kv put secret/kubeconfig value=-
 
       echo "Stopping port-forward..."
-      kill $PF_PID
+      # kill $PF_PID || true
+      pkill -f 'kubectl port-forward svc/vault -n ${var.vault_ns} 8200:8200' || true
     EOT
   }
 }
@@ -183,7 +184,7 @@ resource "null_resource" "vault_retrieve_kubeconfig" {
       done
 
       export VAULT_ADDR='http://127.0.0.1:8200'
-      export VAULT_TOKEN=$(cat ~/.vault-token)
+      # export VAULT_TOKEN=$(cat ~/.vault-token)
 
       echo "Backing up existing kubeconfig to ~/.kube/config.bak"
       mkdir -p ~/.kube


### PR DESCRIPTION
This pull request makes minor updates to the Vault initialization and kubeconfig storage/retrieval scripts in `terraform/vault.tf`. The main change is disabling the use of the `~/.vault-token` file and updating how the Vault port-forward process is terminated.

Most important changes:

**Vault token management:**
* Commented out the line that writes the Vault root token to `~/.vault-token` during Vault initialization, and disabled reading the token from this file in both the kubeconfig store and retrieve scripts. This means the scripts will no longer rely on `~/.vault-token` for authentication. [[1]](diffhunk://#diff-0c32cd254aedd0688fa82d76acaf18f85700e6244b99c4746b6bfea4767b5e81L125-R125) [[2]](diffhunk://#diff-0c32cd254aedd0688fa82d76acaf18f85700e6244b99c4746b6bfea4767b5e81L149-R149) [[3]](diffhunk://#diff-0c32cd254aedd0688fa82d76acaf18f85700e6244b99c4746b6bfea4767b5e81L186-R187)

**Process cleanup:**
* Updated the port-forward cleanup step to comment out the direct `kill $PF_PID` command and instead use `pkill` to terminate the port-forward process by matching its command line, making the cleanup more robust.…tialization and kubeconfig storage