### PR TITLE
Refactor port-forward commands in vault initialization and kubeconfig…

### DIFF
--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -94,7 +94,7 @@ resource "null_resource" "vault_port_forward" {
       kubectl port-forward svc/vault -n ${var.vault_ns} 8200:8200 >/tmp/vault-pf.log 2>&1 &
       echo "Vault UI should be available at http://localhost:8200/ui"
       echo "To stop port-forward, kill the background process:"
-      echo "  pkill -f 'kubectl port-forward svc/vault -n ${var.vault_ns} 8200:8200'"
+      echo "pkill -f 'kubectl port-forward svc/vault -n ${var.vault_ns} 8200:8200'"
     EOT
     # Keep this running during apply, or run detached (this is a simple fire-and-forget)
   }
@@ -112,6 +112,7 @@ resource "null_resource" "vault_init" {
 
       if [ "$IS_INIT" = "true" ]; then
         echo "Vault is already initialized, skipping init"
+        pkill -f 'kubectl port-forward svc/vault -n ${var.vault_ns} 8200:8200' 2>&1
       else
         echo "Initializing Vault..."
         kubectl exec -n ${var.vault_ns} vault-0 -- vault operator init -key-shares=1 -key-threshold=1 > ~/vault_init.txt
@@ -161,8 +162,8 @@ resource "null_resource" "vault_store_kubeconfig" {
       cat ~/.kube/config | vault kv put secret/kubeconfig value=-
 
       echo "Stopping port-forward..."
-      # kill $PF_PID || true
-      pkill -f 'kubectl port-forward svc/vault -n ${var.vault_ns} 8200:8200' || true
+      kill $PF_PID 2>&1
+      # pkill -f 'kubectl port-forward svc/vault -n ${var.vault_ns} 8200:8200' || true
     EOT
   }
 }
@@ -206,8 +207,8 @@ resource "null_resource" "vault_retrieve_kubeconfig" {
       fi
 
       echo "Stopping port-forward..."
-      # kill $PF_PID || true
-      pkill -f 'kubectl port-forward svc/vault -n ${var.vault_ns} 8200:8200' || true
+      kill $PF_PID 2>&1
+      # pkill -f 'kubectl port-forward svc/vault -n ${var.vault_ns} 8200:8200' || true
     EOT
   }
 }


### PR DESCRIPTION
This pull request updates the way port-forwarding processes are terminated in the Vault Terraform scripts. The main change is replacing the use of `pkill` with a direct `kill` command using the process ID variable, which provides more precise control and avoids potential issues with killing unintended processes.

**Improvements to process management:**

* Updated the port-forward termination logic in `vault_store_kubeconfig` and `vault_retrieve_kubeconfig` resources to use `kill $PF_PID` instead of `pkill -f`, ensuring only the intended process is stopped. [[1]](diffhunk://#diff-0c32cd254aedd0688fa82d76acaf18f85700e6244b99c4746b6bfea4767b5e81L164-R166) [[2]](diffhunk://#diff-0c32cd254aedd0688fa82d76acaf18f85700e6244b99c4746b6bfea4767b5e81L209-R211)
* Commented out the previous `pkill -f` commands and added the new approach for clarity and possible troubleshooting. [[1]](diffhunk://#diff-0c32cd254aedd0688fa82d76acaf18f85700e6244b99c4746b6bfea4767b5e81L164-R166) [[2]](diffhunk://#diff-0c32cd254aedd0688fa82d76acaf18f85700e6244b99c4746b6bfea4767b5e81L209-R211)

**Consistency in initialization logic:**

* Added a `pkill -f` command to the Vault initialization resource to ensure any lingering port-forward processes are stopped if Vault is already initialized.… storage for improved clarity and error handling