### PR TITLE
Update kubeconfig generation to use cluster_name variable for consist…

### DIFF
--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -156,7 +156,7 @@ resource "null_resource" "vault_store_kubeconfig" {
       fi
 
       echo "Generating fresh kubeconfig with aws CLI"
-      aws eks update-kubeconfig --name ${aws_eks_cluster.eks.name} --region ${var.region}
+      aws eks update-kubeconfig --name ${var.cluster_name} --region ${var.region}
 
       echo "Storing kubeconfig in Vault..."
       cat ~/.kube/config | vault kv put secret/kubeconfig value=-


### PR DESCRIPTION
This pull request makes a minor update to the way the kubeconfig is generated for EKS clusters in the Vault provisioning script. The change ensures that the cluster name is sourced from the `cluster_name` variable instead of the EKS resource name, improving flexibility and consistency.

* Updated the `aws eks update-kubeconfig` command to use the `${var.cluster_name}` variable instead of `${aws_eks_cluster.eks.name}` for specifying the cluster name.…ency
This pull request makes a small change to the way the EKS cluster name is referenced when generating the kubeconfig with the AWS CLI. Instead of using the cluster name from the `aws_eks_cluster.eks` resource, it now uses the value from the `var.cluster_name` variable. This improves flexibility and consistency in how the cluster name is sourced.