### PR TITLE
Terraform

### DIFF
--- a/scripts/fwd-services.sh
+++ b/scripts/fwd-services.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 # Forward ports for services
-kubectl port-forward -n vault-ns svc/vault 8200:8200 &>/dev/null &
-kubectl port-forward -n monitoring-ns svc/prometheus-prometheus-node-exporter 9100:9100 &>/dev/null &
-kubectl port-forward -n monitoring-ns svc/prometheus-grafana 3000:80 &>/dev/null &
-kubectl port-forward -n monitoring-ns svc/prometheus-kube-prometheus-prometheus 9090:9090 &>/dev/null &
+kubectl port-forward -n vault-ns svc/vault 8200:8200 >/tmp/vault-pf.log 2>&1 &
+kubectl port-forward -n monitoring-ns svc/prometheus-prometheus-node-exporter 9100:9100 >/tmp/exporter-pf.log 2>&1 &
+kubectl port-forward -n monitoring-ns svc/prometheus-grafana 3000:80 >/tmp/grafana-pf.log 2>&1 &
+kubectl port-forward -n monitoring-ns svc/prometheus-kube-prometheus-prometheus 9090:9090 >/tmp/prometheus-pf.log 2>&1 &
+# kubectl port-forward -n monitoring-ns svc/prometheus-cloudwatch-exporter 9106:9106 >/tmp/cloudwatch-pf.log 2>&1 &

--- a/scripts/oidc-provider-url.sh
+++ b/scripts/oidc-provider-url.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+export AWS_PAGER=""
+
+set -euo pipefail
+
+CLUSTER_NAME="eks-demo-cluster"
+REGION="us-east-1"
+
+aws eks describe-cluster \
+  --name $CLUSTER_NAME \
+  --region $REGION \
+  --query "cluster.identity.oidc.issuer" \
+  --output text

--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -1,23 +1,3 @@
-# resource "helm_release" "cloudwatch_exporter" {
-#   depends_on       = [aws_eks_node_group.node_group]
-#   name             = "prometheus-cloudwatch-exporter"
-#   repository       = "https://prometheus-community.github.io/helm-charts"
-#   chart            = "prometheus-cloudwatch-exporter"
-#   namespace        = "monitoring"
-#   create_namespace = true
-#   timeout          = 600
-
-#   set {
-#     name  = "service.type"
-#     value = "ClusterIP"
-#   }
-
-#   set {
-#     name  = "aws.region"
-#     value = var.region
-#   }
-# }
-
 resource "helm_release" "prometheus" {
   depends_on = [
     aws_eks_node_group.node_group,
@@ -35,49 +15,42 @@ resource "helm_release" "prometheus" {
   namespace        = var.monitoring_ns
   create_namespace = true
   timeout          = 600
-  wait             = false
-
-  set {
-    name  = "prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues"
-    value = true
-  }
-
-  # set {
-  #   name  = "prometheus.prometheusSpec.serviceMonitorSelector"
-  #   value = "{}"
-  # }
-
-  set {
-    name  = "grafana.enabled"
-    value = true
-  }
-
-  set {
-    name  = "grafana.service.type"
-    value = "ClusterIP"
-  }
-
-  set {
-    name  = "grafana.service.port"
-    value = "80"
-  }
+  skip_crds        = false
+  wait             = true
+  version          = "76.4.0"
 }
-
+#   set {
+#     name  = "prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues"
+#     value = true
+#   }
+#   set {
+#     name  = "prometheus.prometheusSpec.serviceMonitorSelector"
+#     value = "{}"
+#   }
+#   set {
+#     name  = "grafana.enabled"
+#     value = true
+#   }
+#   set {
+#     name  = "grafana.service.type"
+#     value = "ClusterIP"
+#   }
+#   set {
+#     name  = "grafana.service.port"
+#     value = "80"
+#   }
 #   set {
 #     name  = "prometheus.service.type"
 #     value = "LoadBalancer"
 #   }
-
 #   set {
 #     name  = "prometheus.service.loadBalancerType"
 #     value = "nlb"
 #   }
-
 #   set {
 #     name  = "grafana.service.type"
 #     value = "LoadBalancer"
 #   }
-
 #   set {
 #     name  = "grafana.service.loadBalancerType"
 #     value = "nlb"
@@ -86,22 +59,18 @@ resource "helm_release" "prometheus" {
 #     name  = "fullnameOverride"
 #     value = "prometheus"
 #   }
-
 #   set {
 #     name  = "global.serviceAnnotations.service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled"
 #     value = "false"
 #   }
-
 #   # Prometheus Service Finalizer Off
 #   set {
 #     name  = "prometheus.service.annotations.service\\.kubernetes\\.io/load-balancer-cleanup"
 #     value = "\"true\""
 #   }
-
 #   # Grafana Service Finalizer Off
 #   set {
 #     name  = "grafana.service.annotations.service\\.kubernetes\\.io/load-balancer-cleanup"
 #     value = "\"true\""
 #   }
-
 # }


### PR DESCRIPTION
This pull request makes several improvements to the monitoring and service forwarding scripts, as well as updates to the Terraform configuration for Prometheus. The main changes include improved logging for port forwarding commands, addition of a helper script for retrieving the OIDC provider URL, and updates to the Helm release configuration for Prometheus. Additionally, the CloudWatch exporter Helm release is removed from Terraform configuration.

**Service and monitoring script improvements:**

* Updated `scripts/fwd-services.sh` to redirect port-forward logs to files in `/tmp` instead of `/dev/null`, making debugging easier. Also commented out the CloudWatch exporter port-forward command.
* Added a new helper script `scripts/oidc-provider-url.sh` to easily fetch the OIDC provider URL for the EKS cluster using AWS CLI.

**Terraform configuration changes:**

* Removed the commented-out `helm_release` resource for the CloudWatch exporter from `terraform/monitoring.tf`, cleaning up unused code.
* Updated the Prometheus Helm release configuration in `terraform/monitoring.tf` to set `skip_crds = false`, `wait = true`, and specify `version = "76.4.0"`. Also commented out several `set` blocks related to Grafana and service monitor selector for future reference.
* Minor cleanup of commented-out blocks at the end of the Prometheus Helm release resource in `terraform/monitoring.tf`.