### PR TITLE
Direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -60,7 +60,7 @@ install_hashicorp_tool() {
             --keyring /usr/share/keyrings/hashicorp-archive-keyring.gpg \
             --fingerprint
             echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(grep -oP '(?<=UBUNTU_CODENAME=).*' /etc/os-release || lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-            sudo apt update && sudo apt-get install terraform -y
+            sudo apt-get install terraform -y
         fi
     else
         echo "$tool already installed."

--- a/.envrc
+++ b/.envrc
@@ -159,11 +159,17 @@ ensure_gke_plugin() {
     fi
 }
 
-wget -O- https://apt.releases.hashicorp.com/gpg | \
-    gpg --dearmor | \
-    sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg > /dev/null
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
-    sudo tee /etc/apt/sources.list.d/hashicorp.list
+ensure_hashicorp_repo() {
+    if [[ "$OS_TYPE" == "Linux" ]] && ! grep -q "hashicorp" /etc/apt/sources.list.d/hashicorp.list 2>/dev/null; then
+        echo "Adding HashiCorp repository..."
+        wget -O- https://apt.releases.hashicorp.com/gpg | \
+            gpg --dearmor | \
+            sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg > /dev/null
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
+            sudo tee /etc/apt/sources.list.d/hashicorp.list
+            apt_update_once
+    fi
+}
 
 # ------------------------------------------------------------
 # Tool Installs
@@ -171,6 +177,7 @@ wget -O- https://apt.releases.hashicorp.com/gpg | \
 
 ensure_gcloud
 ensure_gke_plugin
+ensure_command awscli
 ensure_command software-properties-common
 ensure_command make
 ensure_command kubectl

--- a/.envrc
+++ b/.envrc
@@ -125,8 +125,39 @@ else
 fi
 
 # ------------------------------------------------------------
-# Tool Installs
+# Special installers
 # ------------------------------------------------------------
+
+ensure_gcloud() {
+    if ! command -v gcloud >/dev/null 2>&1; then
+        echo "Installing Google Cloud CLI..."
+        if [[ "$OS_TYPE" == "Linux" ]]; then
+            install_package apt-transport-https
+            install_package ca-certificates
+            install_package gnupg
+            install_package curl
+            curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+                sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+            echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
+                sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
+            apt_update_once
+            sudo apt-get install -y google-cloud-cli >/dev/null
+        else
+            install_package gcloud
+        fi
+    else
+        echo "gcloud is already installed."
+    fi
+}
+
+ensure_gke_plugin() {
+    if ! command -v gke-gcloud-auth-plugin >/dev/null 2>&1; then
+        echo "Installing gke-gcloud-auth-plugin..."
+        [[ "$OS_TYPE" == "Linux" ]] && install_package google-cloud-sdk-gke-gcloud-auth-plugin >/dev/null
+    else
+        echo "gke-gcloud-auth-plugin already installed."
+    fi
+}
 
 wget -O- https://apt.releases.hashicorp.com/gpg | \
     gpg --dearmor | \
@@ -134,7 +165,13 @@ wget -O- https://apt.releases.hashicorp.com/gpg | \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
     sudo tee /etc/apt/sources.list.d/hashicorp.list
 
-ensure_command gnupg software-properties-common
+# ------------------------------------------------------------
+# Tool Installs
+# ------------------------------------------------------------
+
+ensure_gcloud
+ensure_gke_plugin
+ensure_command software-properties-common
 ensure_command make
 ensure_command kubectl
 ensure_command jq

--- a/.envrc
+++ b/.envrc
@@ -124,6 +124,18 @@ else
     echo "session-manager-plugin is already installed."
 fi
 
+# ------------------------------------------------------------
+# Tool Installs
+# ------------------------------------------------------------
+
+install_hashicorp_tool terraform
+install_hashicorp_tool vault
+ensure_command make
+ensure_command kubectl
+ensure_command jq
+ensure_command docker docker.io docker-buildx
+ensure_command helm
+ensure_command pass
 
 # ------------------------------------------------------------
 # AWS Credentials (from pass)
@@ -138,19 +150,6 @@ else
     echo "Not authenticated with AWS. Configure your AWS CLI."
     exit 1
 fi
-
-# ------------------------------------------------------------
-# Tool Installs
-# ------------------------------------------------------------
-
-install_hashicorp_tool terraform
-install_hashicorp_tool vault
-ensure_command make
-ensure_command kubectl
-ensure_command jq
-ensure_command docker docker.io docker-buildx
-ensure_command helm
-ensure_command pass
 
 # ------------------------------------------------------------
 # Vault Environment

--- a/.envrc
+++ b/.envrc
@@ -51,16 +51,7 @@ install_hashicorp_tool() {
             brew tap hashicorp/tap >/dev/null 2>&1 || true
             brew install "hashicorp/tap/$tool"
         else
-            # install_package "$tool"
-            sudo apt-get update && sudo apt-get install -y gnupg software-properties-common
-            wget -O- https://apt.releases.hashicorp.com/gpg | \
-            gpg --dearmor | \
-            sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg > /dev/null
-            gpg --no-default-keyring \
-            --keyring /usr/share/keyrings/hashicorp-archive-keyring.gpg \
-            --fingerprint
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(grep -oP '(?<=UBUNTU_CODENAME=).*' /etc/os-release || lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-            sudo apt-get install terraform -y
+            install_package "$tool"
         fi
     else
         echo "$tool already installed."
@@ -137,14 +128,21 @@ fi
 # Tool Installs
 # ------------------------------------------------------------
 
-install_hashicorp_tool terraform
-install_hashicorp_tool vault
+wget -O- https://apt.releases.hashicorp.com/gpg | \
+    gpg --dearmor | \
+    sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg > /dev/null
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
+    sudo tee /etc/apt/sources.list.d/hashicorp.list
+
+ensure_command gnupg software-properties-common
 ensure_command make
 ensure_command kubectl
 ensure_command jq
 ensure_command docker docker.io docker-buildx
 ensure_command helm
 ensure_command pass
+install_hashicorp_tool terraform
+install_hashicorp_tool vault
 
 # ------------------------------------------------------------
 # AWS Credentials (from pass)

--- a/.envrc
+++ b/.envrc
@@ -51,7 +51,16 @@ install_hashicorp_tool() {
             brew tap hashicorp/tap >/dev/null 2>&1 || true
             brew install "hashicorp/tap/$tool"
         else
-            install_package "$tool"
+            # install_package "$tool"
+            sudo apt-get update && sudo apt-get install -y gnupg software-properties-common
+            wget -O- https://apt.releases.hashicorp.com/gpg | \
+            gpg --dearmor | \
+            sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg > /dev/null
+            gpg --no-default-keyring \
+            --keyring /usr/share/keyrings/hashicorp-archive-keyring.gpg \
+            --fingerprint
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(grep -oP '(?<=UBUNTU_CODENAME=).*' /etc/os-release || lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+            sudo apt update && sudo apt-get install terraform -y
         fi
     else
         echo "$tool already installed."


### PR DESCRIPTION
This pull request refactors the `.envrc` setup script to improve modularity and reliability of cloud tooling installation. The main changes include moving AWS credential setup below tool installations, introducing new installer functions for Google Cloud and HashiCorp tools, and improving installation checks for required commands.

Improvements to cloud tooling installation:

* Added `ensure_gcloud` and `ensure_gke_plugin` functions to automate and modularize the installation of Google Cloud CLI and GKE authentication plugin, with OS-specific logic.
* Added `ensure_hashicorp_repo` function to automatically add the HashiCorp APT repository on Linux systems if missing.

Refactoring and ordering:

* Moved AWS credential export and authentication check below the tool installation section to ensure required tools are available before accessing credentials.
* Improved installation commands by adding `ensure_command` for several utilities (`awscli`, `software-properties-common`, etc.) to check and install them if missing.

General reliability:

* Updated the script to provide clearer status messages about the installation and authentication state of cloud tools and credentials.