### PR TITLE
Enhance package installation checks for Homebrew and streamline Google Cloud CLI setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -23,6 +23,12 @@ install_package() {
     case "$OS_TYPE" in
         Darwin)
             command -v brew >/dev/null 2>&1 || { echo "Install Homebrew first"; exit 1; }
+            if ! brew list "$pkg" >/dev/null 2>&1; then
+                echo "Installing $pkg via Homebrew..."
+            else
+                echo "$pkg already installed."
+                return
+            fi
             brew install "$pkg"
             ;;
         Linux)
@@ -132,6 +138,7 @@ ensure_gcloud() {
     if ! command -v gcloud >/dev/null 2>&1; then
         echo "Installing Google Cloud CLI..."
         if [[ "$OS_TYPE" == "Linux" ]]; then
+            install_package software-properties-common
             install_package apt-transport-https
             install_package ca-certificates
             install_package gnupg
@@ -178,7 +185,6 @@ ensure_hashicorp_repo() {
 ensure_gcloud
 ensure_gke_plugin
 ensure_command awscli
-ensure_command software-properties-common
 ensure_command make
 ensure_command kubectl
 ensure_command jq


### PR DESCRIPTION
This pull request makes improvements to the `.envrc` setup script, focusing on more robust package installation and streamlining dependency management for Linux environments.

**Improvements to package installation logic:**

* Added a check in `install_package()` to avoid reinstalling packages with Homebrew if they are already present, providing clearer feedback to the user.

**Streamlining Linux dependency management:**

* Ensured `software-properties-common` is installed as part of the Google Cloud CLI setup on Linux by adding it to the `ensure_gcloud()` function.
* Removed a redundant call to `ensure_command software-properties-common` from the main setup sequence, since it is now handled in `ensure_gcloud()`.