### PR TITLE
Refactor AWS CLI installation and ensure command checks for improved …

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -65,8 +65,6 @@ ensure_command() {
 # AWS CLI + Config
 # ------------------------------------------------------------
 
-ensure_command aws awscli
-
 AWS_CONFIG="$HOME/.aws/config"
 if [[ ! -f "$AWS_CONFIG" ]]; then
     mkdir -p "$HOME/.aws"
@@ -104,14 +102,20 @@ fi
 # Special installers
 # ------------------------------------------------------------
 
+ensure_awscli() {
+    if ! command -v aws >/dev/null 2>&1 && [[ "$OS_TYPE" == "Linux" ]]; then
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "/tmp/awscliv2.zip"
+        unzip /tmp/awscliv2.zip -d /tmp
+        sudo /tmp/aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
+    fi
+}
+
 ensure_helm() {
     if ! command -v helm >/dev/null 2>&1 && [[ "$OS_TYPE" == "Linux" ]]; then
         curl -fsSL https://baltocdn.com/helm/signing.asc | gpg --dearmor | \
           sudo tee /usr/share/keyrings/helm.gpg >/dev/null
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | \
-          sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-        apt_update_once
-        install_package helm
+          sudo tee /etc/apt/sources.list.d/helm-stable-debian.list >/dev/null
     fi
 }
 
@@ -130,8 +134,6 @@ ensure_kubectl() {
           sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
         echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.33/deb/ /" | \
           sudo tee /etc/apt/sources.list.d/kubernetes.list >/dev/null
-        apt_update_once
-        install_package kubectl
     fi
 }
 
@@ -139,13 +141,17 @@ ensure_kubectl() {
 # Tool Installs
 # ------------------------------------------------------------
 
-ensure_command make
+
 ensure_kubectl
+ensure_helm
+ensure_hashicorp_repo
+ensure_awscli
+ensure_command make
 ensure_command jq
 ensure_command docker docker.io
 ensure_command pass
-ensure_helm
-ensure_hashicorp_repo
+ensure_command helm
+ensure_command kubectl
 install_hashicorp_tool terraform
 install_hashicorp_tool vault
 


### PR DESCRIPTION
This pull request refactors how key command-line tools are installed and ensured in the `.envrc` environment setup script. The main improvements are the introduction of specialized installer functions for tools like AWS CLI and Helm, and a reordering of installation steps to improve clarity and reliability.

**Installer function refactoring:**

* Added a new `ensure_awscli()` function to handle AWS CLI installation on Linux, including downloading and installing the official package if not present.
* Modified the `ensure_helm()` function to only set up the repository and GPG key, removing direct installation steps to separate concerns.
* Removed the previous generic `ensure_command aws awscli` call in favor of the new specialized installer.

**Tool installation ordering and reliability:**

* Changed the order in which installer functions are called, ensuring that `ensure_kubectl`, `ensure_helm`, `ensure_hashicorp_repo`, and `ensure_awscli` are invoked before generic `ensure_command` calls, improving setup consistency.
* Updated the calls for `helm` and `kubectl` to use both the installer functions and generic `ensure_command` for redundancy, and removed direct install steps from the installer functions.