### PR TITLE
Docker cross platform compatability

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -148,7 +148,7 @@ ensure_hashicorp_repo
 ensure_awscli
 ensure_command make
 ensure_command jq
-ensure_command docker docker.io
+ensure_command docker-buildx
 ensure_command pass
 ensure_command helm
 ensure_command kubectl

--- a/scripts/docker-image.sh
+++ b/scripts/docker-image.sh
@@ -43,7 +43,7 @@ IMAGE_EXISTS=$(aws ecr describe-images \
 
 if [[ "${IMAGE_EXISTS}" == "[]" ]]; then
   echo "🚫 Image with tag '${IMAGE_TAG}' not found. Building and pushing..."
-  docker build \
+  docker buildx build \
   --platform ${PLATFORM_ARCH} \
   -t ${LOCAL_IMAGE_NAME}:${IMAGE_TAG} .
   docker tag ${LOCAL_IMAGE_NAME}:${IMAGE_TAG} ${ECR_URI}

--- a/terraform/deploys.tf
+++ b/terraform/deploys.tf
@@ -107,7 +107,7 @@ resource "kubernetes_deployment" "hello_world" {
         container {
           name              = var.deployment
           image_pull_policy = "Always"
-          image             = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.repo_name}:${var.image_tag}@${var.image_digest}"
+          image             = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.repo_name}:${var.image_tag}" # @${var.image_digest}"
           # image             = "adamrocha/hello-world-demo:1.2.0"
           # image             = "hashicorp/http-echo:1.0"
           # args              = ["-text=👋 Hello from Kubernetes!"]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -72,7 +72,7 @@ variable "image_tag" {
 
 variable "image_digest" {
   description = "Digest of the Docker image to be used in the deployment"
-  default     = "sha256:4282cb9a2f11afbc058a0cbdaf906831630e974aa8da9c0c89d9ffcb127fc4e5"
+  default     = "sha256:2dc5477d19b1457ce0550f682a40fa526139f31de999d5bfd314c6e8a19ac8aa"
   type        = string
 
 }


### PR DESCRIPTION
This pull request updates the Docker build process and Kubernetes deployment configuration to improve compatibility with modern Docker tooling and simplify image management. The main changes include switching to `docker-buildx` for building images and removing the use of image digests in the Kubernetes deployment resource.

**Docker build and deployment process updates:**

* Switched from `docker` to `docker-buildx` for building images in both the `.envrc` setup and the `scripts/docker-image.sh` script, enabling multi-platform builds and modern Docker features. [[1]](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430L151-R151) [[2]](diffhunk://#diff-090c30899dee381723a9fdde7ceb8ed16428ddadccb7fcfea02a116082c17249L46-R46)

**Kubernetes deployment configuration changes:**

* Updated the `kubernetes_deployment` resource in `terraform/deploys.tf` to use only the image tag (removed digest from the image reference) for easier image updates and management.

**Terraform variable updates:**

* Changed the default value of the `image_digest` variable in `terraform/variables.tf` to reflect a new image digest, though digest is now commented out in deployment usage.