### PR TITLE
Terraform

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,15 +1,19 @@
 provider "aws" {}
 
 provider "kubernetes" {
-  host                   = aws_eks_cluster.eks.endpoint
-  cluster_ca_certificate = base64decode(aws_eks_cluster.eks.certificate_authority[0].data)
-  token                  = data.aws_eks_cluster_auth.eks.token
+  host  = aws_eks_cluster.eks.endpoint
+  token = data.aws_eks_cluster_auth.eks.token
+  cluster_ca_certificate = base64decode(
+    aws_eks_cluster.eks.certificate_authority[0].data
+  )
 }
 
 provider "helm" {
-  kubernetes {
-    host                   = aws_eks_cluster.eks.endpoint
-    cluster_ca_certificate = base64decode(aws_eks_cluster.eks.certificate_authority[0].data)
-    token                  = data.aws_eks_cluster_auth.eks.token
+  kubernetes = {
+    host  = aws_eks_cluster.eks.endpoint
+    token = data.aws_eks_cluster_auth.eks.token
+    cluster_ca_certificate = base64decode(
+      aws_eks_cluster.eks.certificate_authority[0].data
+    )
   }
 }

--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -18,59 +18,72 @@ resource "helm_release" "vault" {
 
   create_namespace = true
 
-  set {
-    name  = "server.dev.enabled"
-    value = "true"
-  }
-  set {
-    name  = "server.ui"
-    value = "true"
-  }
-
-  set {
-    name  = "server.ha.enabled"
-    value = "true"
-  }
-
-  set {
-    name  = "server.ha.replicas"
-    value = "3"
-  }
-
-  set {
-    name  = "server.ha.storage.type"
-    value = "consul"
-  }
-
-  set {
-    name  = "server.ha.storage.consul.address"
-    value = "consul:8500"
-  }
-
-  set {
-    name  = "server.ha.storage.consul.path"
-    value = "vault/"
-  }
-
-  set {
-    name  = "injector.enabled"
-    value = "true"
-  }
-
-  set {
-    name  = "injector.replicaCount"
-    value = "1"
-  }
-
-  set {
-    name  = "injector.authPath"
-    value = "auth/kubernetes"
-  }
-
-  set {
-    name  = "injector.logLevel"
-    value = "info"
-  }
+  set = [
+    {
+      name  = "server.dev.enabled"
+      value = "true"
+    },
+    {
+      name  = "server.ui"
+      value = "true"
+    },
+    {
+      name  = "server.ha.enabled"
+      value = "true"
+    },
+    {
+      name  = "server.ha.replicas"
+      value = "3"
+    },
+    {
+      name  = "server.ha.storage.type"
+      value = "consul"
+    },
+    {
+      name  = "server.ha.storage.consul.address"
+      value = "consul:8500"
+    },
+    {
+      name  = "server.ha.storage.consul.path"
+      value = "vault/"
+    },
+    {
+      name  = "injector.enabled"
+      value = "true"
+    },
+    {
+      name  = "injector.replicaCount"
+      value = "1"
+    },
+    {
+      name  = "injector.image.tag"
+      value = "0.13.0"
+    },
+    {
+      name  = "injector.resources.limits.cpu"
+      value = "100m"
+    },
+    {
+      name  = "injector.resources.limits.memory"
+      value = "128Mi"
+    },
+    {
+      name  = "injector.resources.requests.cpu"
+      value = "100m"
+    },
+    {
+      name  = "injector.resources.requests.memory"
+      value = "128Mi"
+    },
+    {
+      name  = "injector.authPath"
+      value = "auth/kubernetes"
+    },
+    {
+      name  = "injector.logLevel"
+      value = "info"
+    }
+  ]
 }
 
 resource "null_resource" "wait_for_vault" {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5.0"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -6,13 +8,27 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.20"
+      version = "~> 2.38"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.12"
+      version = "~> 3.0"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 3.5"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 3.21"
+    }
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.3"
     }
   }
-
-  required_version = ">= 1.3.0"
 }


### PR DESCRIPTION
This pull request updates the Terraform configuration to improve provider compatibility, modernize Helm chart settings, and enhance resource management for Vault deployment. The most important changes are grouped below by theme.

**Provider and Version Updates:**

* Updated required Terraform version to `>= 1.5.0` and bumped provider versions for `kubernetes`, `helm`, and added/updated several other providers (`http`, `null`, `vault`, `external`) in `terraform/versions.tf` for better compatibility and feature support.

**Configuration Consistency and Readability:**

* Reformatted the `cluster_ca_certificate` assignment for both `kubernetes` and `helm` providers in `terraform/providers.tf` to improve readability and maintain consistency.

**Vault Helm Release Improvements:**

* Refactored the `set` blocks in `helm_release.vault` to use a single `set` list, simplifying configuration and making it easier to manage multiple settings in `terraform/vault.tf`.
* Added new settings for Vault injector, including image tag, resource limits, and resource requests, to enhance resource management and deployment reliability.