### PR TITLE
Make

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,172 +1,39 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-export PROJECT_ROOT
+# PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# export PROJECT_ROOT
 
-OS_TYPE="$(uname -s)"
-APT_UPDATED=0
-
-# ------------------------------------------------------------
-# Helpers
-# ------------------------------------------------------------
-
-apt_update_once() {
-    if [[ $APT_UPDATED -eq 0 ]]; then
-        sudo apt-get update -qq -y
-        APT_UPDATED=1
-    fi
-}
-
-install_package() {
-    local pkg="$1"
-    case "$OS_TYPE" in
-        Darwin)
-            if ! command -v brew >/dev/null 2>&1; then
-                echo "Install Homebrew first"; exit 1
-            fi
-            brew list --versions "$pkg" >/dev/null 2>&1 || brew install "$pkg"
-            ;;
-        Linux)
-            if command -v apt-get >/dev/null 2>&1; then
-                apt_update_once
-                sudo NEEDRESTART_MODE=a apt-get install -y -qq "$pkg"
-            elif command -v yum >/dev/null 2>&1; then
-                sudo yum install -y -q "$pkg"
-            else
-                echo "Unsupported Linux package manager. Install $pkg manually."; exit 1
-            fi
-            ;;
-        *) echo "Unsupported OS: $OS_TYPE"; exit 1 ;;
-    esac
-}
-
-install_hashicorp_tool() {
-    local tool="$1"
-    if ! command -v "$tool" >/dev/null 2>&1; then
-        if [[ "$OS_TYPE" == "Darwin" ]]; then
-            brew tap hashicorp/tap >/dev/null 2>&1 || true
-            brew install "hashicorp/tap/$tool"
-        elif [[ "$OS_TYPE" == "Linux" ]]; then
-            ensure_hashicorp_repo
-            apt_update_once
-            install_package "$tool"
-        fi
-    fi
-}
-
-ensure_command() {
-    local cmd="$1"
-    local pkg="${2:-$1}"
-    command -v "$cmd" >/dev/null 2>&1 || install_package "$pkg"
-}
+export PROJECT_ROOT="${PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 
 # ------------------------------------------------------------
-# AWS CLI + Config
+# AWS Credentials
 # ------------------------------------------------------------
 
-AWS_CONFIG="$HOME/.aws/config"
-if [[ ! -f "$AWS_CONFIG" ]]; then
-    mkdir -p "$HOME/.aws"
-    cat > "$AWS_CONFIG" <<'EOF'
-[default]
-region = us-east-1
-output = json
+# export AWS_ACCESS_KEY_ID="$(pass aws/dev/aws_access_key_id)"
+# export AWS_SECRET_ACCESS_KEY="$(pass aws/dev/aws_secret_access_key)"
 
-[profile prom_infradmin]
-region = us-east-1
-output = json
-EOF
+# aws sts get-caller-identity >/dev/null || { echo "Not authenticated with AWS"; exit 1; }
+
+if ! command -v pass >/dev/null 2>&1; then
+    echo "pass command not found. Please run 'make installs' for tooling setup."
+    exit 1
+else
+    export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-$(pass aws/dev/aws_access_key_id)}"
+    export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-$(pass aws/dev/aws_secret_access_key)}"
 fi
 
-# ------------------------------------------------------------
-# Session Manager Plugin
-# ------------------------------------------------------------
-
-if ! command -v session-manager-plugin >/dev/null 2>&1; then
-    ARCH="$(uname -m)"
-    case "$OS_TYPE-$ARCH" in
-        Darwin-*) brew install --cask session-manager-plugin ;;
-        Linux-x86_64|Linux-amd64) URL="https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" ;;
-        Linux-aarch64|Linux-arm64) URL="https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_arm64/session-manager-plugin.deb" ;;
-        *) echo "Unsupported OS/arch: $OS_TYPE-$ARCH"; exit 1 ;;
-    esac
-    if [[ "${URL:-}" ]]; then
-        curl -fsSL "$URL" -o /tmp/session-manager-plugin.deb
-        sudo dpkg -i /tmp/session-manager-plugin.deb || sudo apt-get -f install -y
-        rm -f /tmp/session-manager-plugin.deb
-    fi
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+  echo "Not authenticated with AWS"
+  exit 1
 fi
-
-# ------------------------------------------------------------
-# Special installers
-# ------------------------------------------------------------
-
-ensure_awscli() {
-    if ! command -v aws >/dev/null 2>&1 && [[ "$OS_TYPE" == "Linux" ]]; then
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "/tmp/awscliv2.zip"
-        unzip /tmp/awscliv2.zip -d /tmp
-        sudo /tmp/aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
-    fi
-}
-
-ensure_helm() {
-    if ! command -v helm >/dev/null 2>&1 && [[ "$OS_TYPE" == "Linux" ]]; then
-        curl -fsSL https://baltocdn.com/helm/signing.asc | gpg --dearmor | \
-          sudo tee /usr/share/keyrings/helm.gpg >/dev/null
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | \
-          sudo tee /etc/apt/sources.list.d/helm-stable-debian.list >/dev/null
-    fi
-}
-
-ensure_hashicorp_repo() {
-    if [[ "$OS_TYPE" == "Linux" ]] && [[ ! -f /etc/apt/sources.list.d/hashicorp.list ]]; then
-        wget -qO- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | \
-          sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg >/dev/null
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
-          sudo tee /etc/apt/sources.list.d/hashicorp.list >/dev/null
-    fi
-}
-
-ensure_kubectl() {
-    if ! command -v kubectl >/dev/null 2>&1 && [[ "$OS_TYPE" == "Linux" ]]; then
-        curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.33/deb/Release.key | \
-          sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-        echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.33/deb/ /" | \
-          sudo tee /etc/apt/sources.list.d/kubernetes.list >/dev/null
-    fi
-}
-
-# ------------------------------------------------------------
-# Tool Installs
-# ------------------------------------------------------------
-
-
-ensure_kubectl
-ensure_helm
-ensure_hashicorp_repo
-ensure_awscli
-ensure_command make
-ensure_command jq
-ensure_command docker-buildx
-ensure_command pass
-ensure_command helm
-ensure_command kubectl
-install_hashicorp_tool terraform
-install_hashicorp_tool vault
-
-# ------------------------------------------------------------
-# AWS Credentials (from pass)
-# ------------------------------------------------------------
-
-export AWS_ACCESS_KEY_ID="$(pass aws/dev/aws_access_key_id)"
-export AWS_SECRET_ACCESS_KEY="$(pass aws/dev/aws_secret_access_key)"
-
-aws sts get-caller-identity >/dev/null || { echo "Not authenticated with AWS"; exit 1; }
 
 # ------------------------------------------------------------
 # Vault Environment
 # ------------------------------------------------------------
 
-export VAULT_ADDR="$(pass vault/dev/address)"
-export VAULT_TOKEN="$(pass vault/dev/token)"
+# export VAULT_ADDR="$(pass vault/dev/address)"
+# export VAULT_TOKEN="$(pass vault/dev/token)"
+
+export VAULT_ADDR="${VAULT_ADDR:-$(pass vault/dev/address)}"
+export VAULT_TOKEN="${VAULT_TOKEN:-$(pass vault/dev/token)}"

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ check-aws:
 		echo "✅ AWS credentials valid."; \
 	fi
 
+install-tools:
+	@echo "🚀 Running install-tools script..."
+	@/bin/bash ./scripts/install-tools.sh
+
 tf-bootstrap: tf-bucket tf-format tf-init tf-validate tf-plan
 	@echo "🔄 Running Terraform bootstrap..."
 	@echo "✅ Terraform tasks completed successfully."

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OS_TYPE="$(uname -s)"
+APT_UPDATED=0
+
+# ------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------
+
+apt_update_once() {
+    if [[ $APT_UPDATED -eq 0 ]]; then
+        sudo apt-get update -qq -y
+        APT_UPDATED=1
+    fi
+}
+
+install_package() {
+    local pkg="$1"
+    case "$OS_TYPE" in
+        Darwin)
+            if ! command -v brew >/dev/null 2>&1; then
+                echo "Install Homebrew first"; exit 1
+            fi
+            brew list --versions "$pkg" >/dev/null 2>&1 || brew install "$pkg"
+            ;;
+        Linux)
+            if command -v apt-get >/dev/null 2>&1; then
+                apt_update_once
+                sudo NEEDRESTART_MODE=a apt-get install -y -qq "$pkg"
+            elif command -v yum >/dev/null 2>&1; then
+                sudo yum install -y -q "$pkg"
+            else
+                echo "Unsupported Linux package manager. Install $pkg manually."; exit 1
+            fi
+            ;;
+        *) echo "Unsupported OS: $OS_TYPE"; exit 1 ;;
+    esac
+}
+
+install_hashicorp_tool() {
+    local tool="$1"
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        if [[ "$OS_TYPE" == "Darwin" ]]; then
+            brew tap hashicorp/tap >/dev/null 2>&1 || true
+            brew install "hashicorp/tap/$tool"
+        elif [[ "$OS_TYPE" == "Linux" ]]; then
+            ensure_hashicorp_repo
+            apt_update_once
+            install_package "$tool"
+        fi
+    fi
+}
+
+ensure_command() {
+    local cmd="$1"
+    local pkg="${2:-$1}"
+    command -v "$cmd" >/dev/null 2>&1 || install_package "$pkg"
+}
+
+# ------------------------------------------------------------
+# AWS CLI + Config
+# ------------------------------------------------------------
+
+AWS_CONFIG="$HOME/.aws/config"
+if [[ ! -f "$AWS_CONFIG" ]]; then
+    mkdir -p "$HOME/.aws"
+    cat > "$AWS_CONFIG" <<'EOF'
+[default]
+region = us-east-1
+output = json
+
+[profile prom_infradmin]
+region = us-east-1
+output = json
+EOF
+fi
+
+# ------------------------------------------------------------
+# Session Manager Plugin
+# ------------------------------------------------------------
+
+if ! command -v session-manager-plugin >/dev/null 2>&1; then
+    ARCH="$(uname -m)"
+    case "$OS_TYPE-$ARCH" in
+        Darwin-*) brew install --cask session-manager-plugin ;;
+        Linux-x86_64|Linux-amd64) URL="https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" ;;
+        Linux-aarch64|Linux-arm64) URL="https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_arm64/session-manager-plugin.deb" ;;
+        *) echo "Unsupported OS/arch: $OS_TYPE-$ARCH"; exit 1 ;;
+    esac
+    if [[ "${URL:-}" ]]; then
+        curl -fsSL "$URL" -o /tmp/session-manager-plugin.deb
+        sudo dpkg -i /tmp/session-manager-plugin.deb || sudo apt-get -f install -y
+        rm -f /tmp/session-manager-plugin.deb
+    fi
+fi
+
+# ------------------------------------------------------------
+# Special installers
+# ------------------------------------------------------------
+
+ensure_awscli() {
+    if ! command -v aws >/dev/null 2>&1 && [[ "$OS_TYPE" == "Linux" ]]; then
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "/tmp/awscliv2.zip"
+        unzip /tmp/awscliv2.zip -d /tmp
+        sudo /tmp/aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
+    fi
+}
+
+ensure_helm() {
+    if ! command -v helm >/dev/null 2>&1 && [[ "$OS_TYPE" == "Linux" ]]; then
+        curl -fsSL https://baltocdn.com/helm/signing.asc | gpg --dearmor | \
+          sudo tee /usr/share/keyrings/helm.gpg >/dev/null
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | \
+          sudo tee /etc/apt/sources.list.d/helm-stable-debian.list >/dev/null
+    fi
+}
+
+ensure_hashicorp_repo() {
+    if [[ "$OS_TYPE" == "Linux" ]] && [[ ! -f /etc/apt/sources.list.d/hashicorp.list ]]; then
+        wget -qO- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | \
+          sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg >/dev/null
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
+          sudo tee /etc/apt/sources.list.d/hashicorp.list >/dev/null
+    fi
+}
+
+ensure_kubectl() {
+    if ! command -v kubectl >/dev/null 2>&1 && [[ "$OS_TYPE" == "Linux" ]]; then
+        curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.33/deb/Release.key | \
+          sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+        echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.33/deb/ /" | \
+          sudo tee /etc/apt/sources.list.d/kubernetes.list >/dev/null
+    fi
+}
+
+# ------------------------------------------------------------
+# Tool Installs
+# ------------------------------------------------------------
+
+
+ensure_kubectl
+ensure_helm
+ensure_hashicorp_repo
+ensure_awscli
+ensure_command make
+ensure_command jq
+ensure_command docker-buildx
+ensure_command pass
+ensure_command helm
+ensure_command kubectl
+install_hashicorp_tool terraform
+install_hashicorp_tool vault


### PR DESCRIPTION
This pull request refactors the developer environment setup by moving all tool installation logic out of `.envrc` and into a dedicated script, improving maintainability and separation of concerns. The `.envrc` file now focuses solely on environment variable setup and AWS/Vault authentication, while a new `install-tools` Makefile target and accompanying `scripts/install-tools.sh` handle all tool installations and configuration. This change makes the setup process more modular and easier to manage.

**Environment setup and authentication changes:**

* `.envrc` now only sets environment variables and checks for AWS/Vault authentication, removing all installation logic and helper functions. AWS credentials are now loaded via `pass` and checked for authentication, with clear error messages for missing dependencies.
* Vault environment variables are set with fallbacks, ensuring they're only loaded if not already present.

**Tool installation and configuration changes:**

* All installation logic (OS/package manager detection, helper functions, AWS CLI/session manager setup, HashiCorp tools, Helm, kubectl, etc.) has been moved from `.envrc` into a new script `scripts/install-tools.sh`, making the process reusable and easier to update.
* A new `install-tools` target has been added to the `Makefile`, allowing developers to run all tool installations with a single command.

**New script for tool setup:**

* The new `scripts/install-tools.sh` script covers all previous installation logic, including package manager detection, AWS CLI configuration, session manager plugin, and required CLI tools for both Linux and MacOS.