### PR TITLE
Cleanup

### DIFF
--- a/scripts/update-kubeconfig.sh
+++ b/scripts/update-kubeconfig.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-# This script sets up the kubeconfig for an EKS cluster.
+#!/usr/bin/env bash
+# This script updates the kubeconfig for an EKS cluster.
 
 
 CLUSTER_NAME="eks-demo-cluster"

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,4 +1,4 @@
-resource "null_resource" "configure_kubectl" {
+resource "null_resource" "update_kubeconfig" {
   depends_on = [aws_eks_cluster.eks]
 
   triggers = { cluster_name = aws_eks_cluster.eks.id }


### PR DESCRIPTION
This pull request updates the naming conventions for the kubeconfig setup process to better reflect its purpose and usage. The main changes include renaming the shell script and the associated Terraform resource to use "update_kubeconfig" instead of "setup_kubeconfig".

Naming and clarity improvements:

* Renamed the shell script from `setup-kubeconfig.sh` to `update-kubeconfig.sh` and updated the script header to clarify its purpose.
* Renamed the Terraform resource from `configure_kubectl` to `update_kubeconfig` in `terraform/locals.tf` for consistency with the updated script name.