### PR TITLE
Fix typo in tooling setup instruction in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -16,7 +16,7 @@ export PROJECT_ROOT="${PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null
 # aws sts get-caller-identity >/dev/null || { echo "Not authenticated with AWS"; exit 1; }
 
 if ! command -v pass >/dev/null 2>&1; then
-    echo "pass command not found. Please run 'make installs' for tooling setup."
+    echo "pass command not found. Please run 'make install-tools' for tooling setup."
     exit 1
 else
     export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-$(pass aws/dev/aws_access_key_id)}"


### PR DESCRIPTION
This pull request makes a minor update to the `.envrc` setup instructions, improving clarity for developers setting up their environment.

* Updated the message to instruct users to run `make install-tools` instead of the incorrect `make installs` when the `pass` command is not found.