### PR TITLE
Refactor Helm release configurations for Prometheus and Vault to impr…

### DIFF
--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -12,65 +12,10 @@ resource "helm_release" "prometheus" {
   name             = "prometheus"
   repository       = "https://prometheus-community.github.io/helm-charts"
   chart            = "kube-prometheus-stack"
+  version          = "76.4.0"
   namespace        = var.monitoring_ns
   create_namespace = true
   timeout          = 600
   skip_crds        = false
   wait             = true
-  version          = "76.4.0"
 }
-#   set {
-#     name  = "prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues"
-#     value = true
-#   }
-#   set {
-#     name  = "prometheus.prometheusSpec.serviceMonitorSelector"
-#     value = "{}"
-#   }
-#   set {
-#     name  = "grafana.enabled"
-#     value = true
-#   }
-#   set {
-#     name  = "grafana.service.type"
-#     value = "ClusterIP"
-#   }
-#   set {
-#     name  = "grafana.service.port"
-#     value = "80"
-#   }
-#   set {
-#     name  = "prometheus.service.type"
-#     value = "LoadBalancer"
-#   }
-#   set {
-#     name  = "prometheus.service.loadBalancerType"
-#     value = "nlb"
-#   }
-#   set {
-#     name  = "grafana.service.type"
-#     value = "LoadBalancer"
-#   }
-#   set {
-#     name  = "grafana.service.loadBalancerType"
-#     value = "nlb"
-#   }
-#   set {
-#     name  = "fullnameOverride"
-#     value = "prometheus"
-#   }
-#   set {
-#     name  = "global.serviceAnnotations.service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled"
-#     value = "false"
-#   }
-#   # Prometheus Service Finalizer Off
-#   set {
-#     name  = "prometheus.service.annotations.service\\.kubernetes\\.io/load-balancer-cleanup"
-#     value = "\"true\""
-#   }
-#   # Grafana Service Finalizer Off
-#   set {
-#     name  = "grafana.service.annotations.service\\.kubernetes\\.io/load-balancer-cleanup"
-#     value = "\"true\""
-#   }
-# }

--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -9,15 +9,13 @@ resource "helm_release" "vault" {
     aws_subnet.public,
     aws_vpc.eks
   ]
-  name       = "vault"
-  namespace  = var.vault_ns
-  repository = "https://helm.releases.hashicorp.com"
-  chart      = "vault"
-  version    = "0.28.0"
-  timeout    = 600
-
+  name             = "vault"
+  repository       = "https://helm.releases.hashicorp.com"
+  chart            = "vault"
+  version          = "0.28.0"
+  namespace        = var.vault_ns
   create_namespace = true
-
+  timeout          = 600
   set = [
     {
       name  = "server.dev.enabled"


### PR DESCRIPTION
This pull request makes minor formatting and ordering improvements to the Helm release resources in the Terraform configuration for monitoring and Vault. The changes do not affect functionality but improve code clarity and consistency.

*Terraform resource formatting and ordering:*

* [`terraform/monitoring.tf`](diffhunk://#diff-67bbb81247775ce347af845bc1a71dfb4d19197d743ddf5d345c2e6dc120c66bR15-L76): Moved the `version` property for the `helm_release` resource for Prometheus to a more conventional location in the block, and removed a large commented-out section of unused Helm value overrides for Prometheus and Grafana.
* [`terraform/vault.tf`](diffhunk://#diff-0c32cd254aedd0688fa82d76acaf18f85700e6244b99c4746b6bfea4767b5e81L13-R18): Reordered the `namespace` and `timeout` properties in the `helm_release` resource for Vault to group related configuration fields together, improving readability.…ove readability and maintainability