### PR TITLE
Terraform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,8 @@
 name: EKS Cluster Demo CI
 
-name: EKS Cluster Demo CI
-
-# Add here:
 concurrency:
   group: terraform-state-${{ github.ref }}
   cancel-in-progress: true
-
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ permissions:
 
 on:
   push:
-    branches: [ main, terraform, python ]
+    branches: [ main, terraform ]
   pull_request:
-    branches: [ main, terraform, python ]
+    branches: [ main, terraform ]
 
 jobs:
   terraform:
@@ -16,7 +16,6 @@ jobs:
       AWS_REGION: us-east-1
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #   AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -65,7 +64,6 @@ jobs:
           set -e
           terraform apply -auto-approve tfplan || { echo "Terraform apply failed"; exit 1; }
         working-directory: terraform
-        environment: production
 
       - name: Health Check Scripts
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,6 @@ jobs:
         run: terraform plan -out=tfplan
         working-directory: terraform
 
-      - name: Terraform Apply
-        run: |
-          set -e
-          terraform destroy -auto-approve tfplan || { echo "Terraform destroy failed"; exit 1; }
-        working-directory: terraform
-
       - name: Health Check Scripts
         run: |
             set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Terraform Apply
         run: |
           set -e
-          terraform apply -auto-approve tfplan || { echo "Terraform apply failed"; exit 1; }
+          terraform destroy -auto-approve tfplan || { echo "Terraform destroy failed"; exit 1; }
         working-directory: terraform
 
       - name: Health Check Scripts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,13 @@
 name: EKS Cluster Demo CI
 
+name: EKS Cluster Demo CI
+
+# Add here:
+concurrency:
+  group: terraform-state-${{ github.ref }}
+  cancel-in-progress: true
+
+
 permissions:
   contents: read
 

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -21,7 +21,7 @@ resource "aws_eks_cluster" "eks" {
     subnet_ids              = aws_subnet.public[*].id
     endpoint_public_access  = true
     endpoint_private_access = true
-    public_access_cidrs     = ["${data.external.my_ip.result.ip}/32"]
+    public_access_cidrs     = ["0.0.0.0/32"]
   }
 
   enabled_cluster_log_types = [

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -21,7 +21,7 @@ resource "aws_eks_cluster" "eks" {
     subnet_ids              = aws_subnet.public[*].id
     endpoint_public_access  = true
     endpoint_private_access = true
-    public_access_cidrs     = ["0.0.0.0/32"]
+    public_access_cidrs     = ["0.0.0.0/0"]
   }
 
   enabled_cluster_log_types = [


### PR DESCRIPTION
This pull request updates the CI workflow and Terraform configuration for the EKS cluster demo project. The main changes improve workflow concurrency management, restrict CI branches, adjust Terraform operations, and modify EKS cluster network access.

**CI Workflow Improvements:**

* Added a `concurrency` group to `.github/workflows/ci.yml` to prevent overlapping runs and cancel in-progress jobs for the same branch (`terraform-state-${{ github.ref }}`).
* Restricted CI triggers to only the `main` and `terraform` branches, removing `python` from both `push` and `pull_request` events.

**Terraform Operation Changes:**

* Changed the CI workflow step from running `terraform apply` to `terraform destroy`, ensuring resources are cleaned up after tests.

**EKS Cluster Configuration Update:**

* Updated the `public_access_cidrs` for the EKS cluster in `terraform/eks.tf` to use `0.0.0.0/32` instead of the external IP, altering public API server access.