### PR TITLE
Update deployment version in index.html to v1.2.5

### DIFF
--- a/kube/index.html
+++ b/kube/index.html
@@ -26,7 +26,7 @@
     </head>
     <body>
         <canvas id="confetti-canvas"></canvas>
-        <h1>&#128640; CI/CD Kubernetes Deployment v{{VERSION}} ! &#128640;</h1>
+        <h1>&#128640; CI/CD Kubernetes Deployment v1.2.5 ! &#128640;</h1>
         <script>
             // Simple confetti effect
             const canvas = document.getElementById('confetti-canvas');


### PR DESCRIPTION
This pull request updates the displayed version number in the Kubernetes deployment page. The change ensures that the header now reflects the current version.

* Updated the version number in the `<h1>` header of `kube/index.html` from `{{VERSION}}` to `v1.2.5` to display the correct deployment version.