### PR TITLE
Refactor EKS CI workflow: streamline branch triggers and update Terra…

### DIFF
--- a/.github/workflows/terraform-eks.yml
+++ b/.github/workflows/terraform-eks.yml
@@ -9,6 +9,7 @@ on:
     branches: [test]
   pull_request:
     branches: [actions]
+  delete:
 
 permissions:
   contents: read
@@ -133,7 +134,10 @@ jobs:
   destroy:
     name: Terraform Destroy on Feature Branch Delete
     runs-on: ubuntu-latest
-    if: github.event.ref_type == 'branch' && startsWith(github.event.ref, 'refs/heads/actions')
+    if: github.event_name == 'delete' && startsWith(github.event.ref, 'actions')
+    environment:
+      name: destroy-approval
+      # Add required reviewers in your repository settings for this environment
     defaults:
       run:
         shell: bash
@@ -153,6 +157,13 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
+
+      - name: Safety check for branch name
+        run: |
+          if [[ "${GITHUB_REF}" != actions/* ]]; then
+            echo "Branch name does not match safety pattern. Skipping destroy."
+            exit 1
+          fi
 
       - name: Terraform Init
         run: terraform init

--- a/.github/workflows/terraform-eks.yml
+++ b/.github/workflows/terraform-eks.yml
@@ -6,9 +6,9 @@ concurrency:
 
 on:
   push:
-    # branches: [ test, actions ]
+    branches: [test]
   pull_request:
-    branches: [ actions ]
+    branches: [actions]
 
 permissions:
   contents: read
@@ -57,12 +57,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2
         with:
-          poetry-version: '2.1.0'
+          poetry-version: "2.1.0"
 
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: '1.13.1'
+          terraform_version: "1.13.1"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -129,3 +129,33 @@ jobs:
             exit 1
           fi
           echo "Rollout succeeded!"
+
+  destroy:
+    name: Terraform Destroy on Feature Branch Delete
+    runs-on: ubuntu-latest
+    if: github.event.ref_type == 'branch' && startsWith(github.event.ref, 'refs/heads/actions')
+    defaults:
+      run:
+        shell: bash
+        working-directory: terraform
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.13.1"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Destroy
+        run: terraform destroy -auto-approve -input=false


### PR DESCRIPTION
This pull request updates the `.github/workflows/terraform-eks.yml` workflow to clarify branch targeting and improve automation for resource cleanup. The most significant change is the addition of a new job that automatically destroys Terraform-managed resources when a feature branch is deleted, helping prevent orphaned infrastructure. Minor formatting updates were also made for consistency.

**Workflow improvements:**

* Added a new `destroy` job that triggers on feature branch deletion (specifically for branches starting with `actions`). This job checks out the code, sets up Terraform, configures AWS credentials, initializes Terraform, and runs `terraform destroy` to clean up resources automatically.

**Configuration and formatting updates:**

* Updated the branch filters for workflow triggers: pushes now only trigger on the `test` branch, while pull requests trigger on the `actions` branch.
* Changed the version strings for Python, Poetry, and Terraform to use double quotes for consistency.…form destroy job