### PR TITLE
Fix typo in CI/CD deployment header in index.html

### DIFF
--- a/kube/index.html
+++ b/kube/index.html
@@ -26,7 +26,7 @@
     </head>
     <body>
         <canvas id="confetti-canvas"></canvas>
-        <h1>&#128640; CI/CD Kubernetes Deployment foo ! &#128640;</h1>
+        <h1>&#128640; CI/CD Kubernetes Deployment! &#128640;</h1>
         <script>
             // Simple confetti effect
             const canvas = document.getElementById('confetti-canvas');


### PR DESCRIPTION
This pull request makes a minor update to the `kube/index.html` file, improving the header text for clarity and presentation. The change removes the extra "foo !" from the deployment message.

* Updated the main header text to remove "foo !" for a cleaner deployment message.