### PR TITLE
Update Terraform Apply step to run on all events except branch deletion

### DIFF
--- a/.github/workflows/terraform-eks.yml
+++ b/.github/workflows/terraform-eks.yml
@@ -99,7 +99,7 @@ jobs:
         run: terraform plan -input=false -out=tfplan
 
       - name: Terraform Apply
-        # if: github.event_name == 'pull_request' && (github.ref_name == 'test' || github.ref_name == 'dev')
+        if: github.event_name != 'delete'
         run: terraform apply -auto-approve tfplan
 
   deploy:


### PR DESCRIPTION
This pull request updates the workflow condition for the Terraform Apply step in `.github/workflows/terraform-eks.yml`. The change ensures that the Terraform Apply step will run for all events except when the event is a branch or tag deletion.

* Workflow logic update:
  * Changed the conditional for the Terraform Apply step to run when `github.event_name` is not `delete`, instead of being commented out or restricted to specific branch names. (`.github/workflows/terraform-eks.yml`)