### PR TITLE
Refactor EKS workflow to remove branch restrictions on push events an…

### DIFF
--- a/.github/workflows/terraform-eks.yml
+++ b/.github/workflows/terraform-eks.yml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   push:
-    # branches: [dev, test, stage]
+    branches: [dev, test, stage]
   pull_request:
     branches: [dev, test, stage]
   delete:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Terraform EKS to improve job naming consistency and ensure jobs only run for relevant events. The changes mainly focus on renaming jobs, updating dependencies, and refining workflow triggers.

Workflow job and trigger improvements:

* Renamed the `terraform` job to `terraform-apply` and updated all dependencies to reflect the new name for better clarity. [[1]](diffhunk://#diff-d5440cd2b8412ce552a5065249e7f7abb71252187c8e9007b513142a2eeef12cL25-R26) [[2]](diffhunk://#diff-d5440cd2b8412ce552a5065249e7f7abb71252187c8e9007b513142a2eeef12cR107-R110)
* Added a conditional check to both `terraform-apply` and `deploy` jobs to skip execution when the workflow is triggered by a `delete` event, preventing unnecessary runs. [[1]](diffhunk://#diff-d5440cd2b8412ce552a5065249e7f7abb71252187c8e9007b513142a2eeef12cL25-R26) [[2]](diffhunk://#diff-d5440cd2b8412ce552a5065249e7f7abb71252187c8e9007b513142a2eeef12cR107-R110)
* Commented out the `push` branch filter to avoid triggering the workflow on direct pushes, focusing execution on pull requests and deletes only.…d clarify job dependencies