### PR TITLE
Enhance destroy job safety check to include 'chore/' branch naming

### DIFF
--- a/.github/workflows/terraform-eks.yml
+++ b/.github/workflows/terraform-eks.yml
@@ -114,7 +114,7 @@ jobs:
   destroy:
     name: Terraform Destroy on Feature Branch Delete
     runs-on: ubuntu-latest
-    if: github.event_name == 'delete' && github.event.ref_type == 'branch' && (startsWith(github.event.ref, 'feature/') || startsWith(github.event.ref, 'fix/'))
+    if: github.event_name == 'delete' && github.event.ref_type == 'branch' && (startsWith(github.event.ref, 'feature/') || startsWith(github.event.ref, 'fix/') || startsWith(github.event.ref, 'chore/'))
     environment:
       name: destroy-approval
       # Add required reviewers in your repository settings for this environment
@@ -137,7 +137,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
       - name: Safety check for branch name
         run: |
-          if [[ ! "${{ github.event.ref }}" =~ ^feature/ ]] && [[ ! "${{ github.event.ref }}" =~ ^fix/ ]] && [[ ! "${{ github.event.ref }}" =~ ^chore/ ]]; then
+          if [[ ! "${{ github.event.ref }}" =~ ^(feature|fix|chore)/ ]]; then
           echo "Branch name does not match safety pattern. Skipping destroy."
           exit 1
           fi


### PR DESCRIPTION
This pull request updates the workflow logic for Terraform destroy jobs in `.github/workflows/terraform-eks.yml` to better support branches prefixed with `chore/`. The changes ensure that the destroy job is triggered and safety checks are performed for `chore/` branches in addition to existing `feature/` and `fix/` branches.

**Workflow trigger and safety check updates:**

* The `destroy` job's conditional trigger now includes branches starting with `chore/` so that Terraform destroy runs when a `chore/` branch is deleted.
* The safety check for branch names in the destroy job script is simplified and now matches `feature/`, `fix/`, and `chore/` branch prefixes using a more concise regular expression.