### PR TITLE
Feature/docker condition

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -72,7 +72,7 @@ variable "image_tag" {
 
 variable "image_digest" {
   description = "Digest of the Docker image to be used in the deployment"
-  default     = "sha256:f2bf6d4c7470408a1424beee699bfe8642f9f7db4c12a292a89a997677b2a56f"
+  default     = "sha256:9dc736d70b3b5ccc9528e9dbd82c9de90983a517ca651fbb1f640450acdb5c87"
   type        = string
 
 }


### PR DESCRIPTION
This pull request introduces a conditional image build step to the Terraform deployment process, ensuring that Docker images are only built when they do not already exist in the AWS ECR repository. Additionally, it updates the default value for the `image_digest` variable.

Image build workflow improvements:

* Added a new `data "external" "image_exists"` block in `terraform/locals.tf` to check if the Docker image with the specified tag exists in AWS ECR before attempting to build the image.
* Modified the `null_resource "image_build"` resource in `terraform/locals.tf` to run only if the image does not exist, using the result from the new external data source.

Configuration update:

* Updated the default value of the `image_digest` variable in `terraform/variables.tf` to a new SHA256 digest.