### PR TITLE
Feature/docker condition

### DIFF
--- a/terraform/deploys.tf
+++ b/terraform/deploys.tf
@@ -107,7 +107,7 @@ resource "kubernetes_deployment" "hello_world" {
         container {
           name              = var.deployment
           image_pull_policy = "Always"
-          image             = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.repo_name}:${var.image_tag}@${var.image_digest}"
+          image             = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.repo_name}:${var.image_tag}@${data.aws_ecr_image.image.image_digest}"
           # image             = "adamrocha/hello-world-demo:1.2.0"
           # image             = "hashicorp/http-echo:1.0"
           # args              = ["-text=👋 Hello from Kubernetes!"]

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -16,9 +16,9 @@ resource "null_resource" "update_kubeconfig" {
 data "external" "image_exists" {
   program = [
     "bash", "-c", <<EOT
-      REGION=${var.region}
-      REPO_NAME=${var.repo_name}
-      IMAGE_TAG=${var.image_tag}
+      REGION="$REGION"
+      REPO_NAME="$REPO_NAME"
+      IMAGE_TAG="$IMAGE_TAG"
 
       if aws ecr describe-images \
           --region "$REGION" \
@@ -32,10 +32,16 @@ data "external" "image_exists" {
       fi
     EOT
   ]
+  query = {
+    REGION    = var.region
+    REPO_NAME = var.repo_name
+    IMAGE_TAG = var.image_tag
+  }
 }
 
 resource "null_resource" "image_build" {
-  count = data.external.image_exists.result.exists == "false" ? 1 : 0
+  # count = data.external.image_exists.result.exists == "false" ? 1 : 0
+  count = data.external.image_exists.result.exists ? 1 : 0
 
   provisioner "local-exec" {
     command     = "../scripts/docker-image.sh"

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -41,7 +41,7 @@ data "external" "image_exists" {
 
 resource "null_resource" "image_build" {
   # count = data.external.image_exists.result.exists == "false" ? 1 : 0
-  count = data.external.image_exists.result.exists ? 1 : 0
+  count = data.external.image_exists.result.exists == "false" ? 1 : 0
 
   provisioner "local-exec" {
     command     = "../scripts/docker-image.sh"

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -40,7 +40,6 @@ data "external" "image_exists" {
 }
 
 resource "null_resource" "image_build" {
-  # count = data.external.image_exists.result.exists == "false" ? 1 : 0
   count = data.external.image_exists.result.exists == "false" ? 1 : 0
 
   provisioner "local-exec" {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -21,10 +21,10 @@ data "external" "image_exists" {
       IMAGE_TAG="$IMAGE_TAG"
 
       if aws ecr describe-images \
-          --region "$REGION" \
-          --repository-name "$REPO_NAME" \
-          --image-ids imageTag="$IMAGE_TAG" \
-          --query "imageDetails[0].imageTags" \
+          --region \"$REGION\" \
+          --repository-name \"$REPO_NAME\" \
+          --image-ids imageTag=\"$IMAGE_TAG\" \
+          --query \"imageDetails[0].imageTags\" \
           --output text >/dev/null 2>&1; then
         echo '{"exists": "true"}'
       else

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -20,12 +20,13 @@ data "external" "image_exists" {
       REPO_NAME="$REPO_NAME"
       IMAGE_TAG="$IMAGE_TAG"
 
-      if aws ecr describe-images \
-          --region \"$REGION\" \
-          --repository-name \"$REPO_NAME\" \
-          --image-ids imageTag=\"$IMAGE_TAG\" \
-          --query \"imageDetails[0].imageTags\" \
-          --output text >/dev/null 2>&1; then
+      IMAGE_COUNT=$(aws ecr describe-images \
+          --region "$REGION" \
+          --repository-name "$REPO_NAME" \
+          --image-ids imageTag="$IMAGE_TAG" \
+          --query "length(imageDetails)" \
+          --output text 2>/dev/null)
+      if [ "$IMAGE_COUNT" -gt 0 ]; then
         echo '{"exists": "true"}'
       else
         echo '{"exists": "false"}'

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -72,7 +72,7 @@ variable "image_tag" {
 
 variable "image_digest" {
   description = "Digest of the Docker image to be used in the deployment"
-  default     = "sha256:f2bf6d4c7470408a1424beee699bfe8642f9f7db4c12a292a89a997677b2a56f"
+  default     = "sha256:9dc736d70b3b5ccc9528e9dbd82c9de90983a517ca651fbb1f640450acdb5c87"
   type        = string
 
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -72,9 +72,8 @@ variable "image_tag" {
 
 variable "image_digest" {
   description = "Digest of the Docker image to be used in the deployment"
-  default     = "sha256:9dc736d70b3b5ccc9528e9dbd82c9de90983a517ca651fbb1f640450acdb5c87"
+  default     = ""
   type        = string
-
 }
 
 variable "tf_state_bucket" {


### PR DESCRIPTION
This pull request updates the Terraform configuration to improve the handling of ECR images and deployments. The main changes include automating ECR repository creation, ensuring images are only built if they don't exist, and safely referencing image digests in deployments.

**ECR Repository and Image Management:**

* Added an `aws_ecr_repository` resource to automatically create the ECR repository with encryption and image scanning enabled, ensuring the repository exists before pushing or referencing images.
* Introduced an external data source (`data.external.image_exists`) to check if the Docker image with the specified tag exists in ECR, allowing conditional logic based on image presence.
* Updated the `null_resource.image_build` to only build and push the image if it does not already exist in ECR, preventing unnecessary builds.
* Added a `data.aws_ecr_image.image` data source to safely look up the image digest for deployment, referencing the actual digest from ECR instead of a hardcoded value.

**Deployment Configuration:**

* Modified the `image` field in the `kubernetes_deployment.hello_world` resource to use the digest from the ECR image data source, ensuring deployments always use the correct image version.
* Changed the default value of the `image_digest` variable to an empty string, removing reliance on a hardcoded digest and shifting to dynamic lookups.