### PR TITLE
Feature/docker condition

### DIFF
--- a/terraform/deploys.tf
+++ b/terraform/deploys.tf
@@ -107,7 +107,7 @@ resource "kubernetes_deployment" "hello_world" {
         container {
           name              = var.deployment
           image_pull_policy = "Always"
-          image             = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.repo_name}:${var.image_tag}@${local.image_digest}"
+          image             = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.repo_name}:${var.image_tag}@${data.aws_ecr_image.image.image_digest}"
           # image             = "adamrocha/hello-world-demo:1.2.0"
           # image             = "hashicorp/http-echo:1.0"
           # args              = ["-text=👋 Hello from Kubernetes!"]

--- a/terraform/deploys.tf
+++ b/terraform/deploys.tf
@@ -107,7 +107,7 @@ resource "kubernetes_deployment" "hello_world" {
         container {
           name              = var.deployment
           image_pull_policy = "Always"
-          image             = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.repo_name}:${var.image_tag}@${data.aws_ecr_image.image.image_digest}"
+          image             = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.repo_name}:${var.image_tag}@${local.image_digest}"
           # image             = "adamrocha/hello-world-demo:1.2.0"
           # image             = "hashicorp/http-echo:1.0"
           # args              = ["-text=👋 Hello from Kubernetes!"]

--- a/terraform/deploys.tf
+++ b/terraform/deploys.tf
@@ -107,7 +107,7 @@ resource "kubernetes_deployment" "hello_world" {
         container {
           name              = var.deployment
           image_pull_policy = "Always"
-          image             = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.repo_name}:${var.image_tag}@${var.image_digest}"
+          image             = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.repo_name}:${var.image_tag}@${data.aws_ecr_image.image.image_digest}"
           # image             = "adamrocha/hello-world-demo:1.2.0"
           # image             = "hashicorp/http-echo:1.0"
           # args              = ["-text=👋 Hello from Kubernetes!"]

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -16,9 +16,9 @@ resource "null_resource" "update_kubeconfig" {
 data "external" "image_exists" {
   program = [
     "bash", "-c", <<EOT
-      REGION=${var.region}
-      REPO_NAME=${var.repo_name}
-      IMAGE_TAG=${var.image_tag}
+      REGION="$REGION"
+      REPO_NAME="$REPO_NAME"
+      IMAGE_TAG="$IMAGE_TAG"
 
       if aws ecr describe-images \
           --region "$REGION" \
@@ -32,10 +32,16 @@ data "external" "image_exists" {
       fi
     EOT
   ]
+  query = {
+    REGION    = var.region
+    REPO_NAME = var.repo_name
+    IMAGE_TAG = var.image_tag
+  }
 }
 
 resource "null_resource" "image_build" {
-  count = data.external.image_exists.result.exists == "false" ? 1 : 0
+  # count = data.external.image_exists.result.exists == "false" ? 1 : 0
+  count = data.external.image_exists.result.exists ? 1 : 0
 
   provisioner "local-exec" {
     command     = "../scripts/docker-image.sh"

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -41,7 +41,7 @@ data "external" "image_exists" {
 
 resource "null_resource" "image_build" {
   # count = data.external.image_exists.result.exists == "false" ? 1 : 0
-  count = data.external.image_exists.result.exists ? 1 : 0
+  count = data.external.image_exists.result.exists == "false" ? 1 : 0
 
   provisioner "local-exec" {
     command     = "../scripts/docker-image.sh"

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -40,7 +40,6 @@ data "external" "image_exists" {
 }
 
 resource "null_resource" "image_build" {
-  # count = data.external.image_exists.result.exists == "false" ? 1 : 0
   count = data.external.image_exists.result.exists == "false" ? 1 : 0
 
   provisioner "local-exec" {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -56,7 +56,7 @@ data "external" "image_exists" {
 
 # Lookup the image safely
 data "aws_ecr_image" "image" {
-  depends_on      = [
+  depends_on = [
     aws_eks_cluster.eks,
     data.external.image_exists
   ]

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -72,7 +72,7 @@ locals {
 
 # Build image only if it doesn't exist
 resource "null_resource" "image_build" {
-  depends_on = [aws_ecr_repository.repo]
+  depends_on = [aws_ecr_repository.repo, data.external.image_exists]
   count      = data.external.image_exists.result.exists == "false" ? 1 : 0
 
   provisioner "local-exec" {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -56,19 +56,16 @@ data "external" "image_exists" {
 
 # Lookup the image safely
 data "aws_ecr_image" "image" {
-  depends_on = [
-    aws_eks_cluster.eks,
-    data.external.image_exists
-  ]
+  depends_on      = [aws_eks_cluster.eks]
   region          = var.region
   repository_name = aws_ecr_repository.repo.name
   image_tag       = var.image_tag
 }
 
 # Use try() to avoid errors when the image doesn't exist
-locals {
-  image_digest = try(data.aws_ecr_image.image.image_digest, "")
-}
+# locals {
+#   image_digest = try(data.aws_ecr_image.image.image_digest, "")
+# }
 
 # Build image only if it doesn't exist
 resource "null_resource" "image_build" {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -65,10 +65,10 @@ data "aws_ecr_image" "image" {
   image_tag       = var.image_tag
 }
 
-# # Use try() to avoid errors when the image doesn't exist
-# locals {
-#   image_digest = try(data.aws_ecr_image.image.image_digest, "")
-# }
+# Use try() to avoid errors when the image doesn't exist
+locals {
+  image_digest = try(data.aws_ecr_image.image.image_digest, "")
+}
 
 # Build image only if it doesn't exist
 resource "null_resource" "image_build" {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -21,10 +21,10 @@ data "external" "image_exists" {
       IMAGE_TAG="$IMAGE_TAG"
 
       if aws ecr describe-images \
-          --region "$REGION" \
-          --repository-name "$REPO_NAME" \
-          --image-ids imageTag="$IMAGE_TAG" \
-          --query "imageDetails[0].imageTags" \
+          --region \"$REGION\" \
+          --repository-name \"$REPO_NAME\" \
+          --image-ids imageTag=\"$IMAGE_TAG\" \
+          --query \"imageDetails[0].imageTags\" \
           --output text >/dev/null 2>&1; then
         echo '{"exists": "true"}'
       else

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -20,12 +20,13 @@ data "external" "image_exists" {
       REPO_NAME="$REPO_NAME"
       IMAGE_TAG="$IMAGE_TAG"
 
-      if aws ecr describe-images \
-          --region \"$REGION\" \
-          --repository-name \"$REPO_NAME\" \
-          --image-ids imageTag=\"$IMAGE_TAG\" \
-          --query \"imageDetails[0].imageTags\" \
-          --output text >/dev/null 2>&1; then
+      IMAGE_COUNT=$(aws ecr describe-images \
+          --region "$REGION" \
+          --repository-name "$REPO_NAME" \
+          --image-ids imageTag="$IMAGE_TAG" \
+          --query "length(imageDetails)" \
+          --output text 2>/dev/null)
+      if [ "$IMAGE_COUNT" -gt 0 ]; then
         echo '{"exists": "true"}'
       else
         echo '{"exists": "false"}'

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -72,7 +72,7 @@ variable "image_tag" {
 
 variable "image_digest" {
   description = "Digest of the Docker image to be used in the deployment"
-  default     = "sha256:f2bf6d4c7470408a1424beee699bfe8642f9f7db4c12a292a89a997677b2a56f"
+  default     = "sha256:9dc736d70b3b5ccc9528e9dbd82c9de90983a517ca651fbb1f640450acdb5c87"
   type        = string
 
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -72,9 +72,8 @@ variable "image_tag" {
 
 variable "image_digest" {
   description = "Digest of the Docker image to be used in the deployment"
-  default     = "sha256:9dc736d70b3b5ccc9528e9dbd82c9de90983a517ca651fbb1f640450acdb5c87"
+  default     = ""
   type        = string
-
 }
 
 variable "tf_state_bucket" {


### PR DESCRIPTION
This pull request introduces improvements to the deployment pipeline for the Kubernetes application, focusing on safer and more automated handling of Docker images in AWS ECR. The main changes ensure that the ECR repository is managed by Terraform, image existence is checked before building, and the deployment references the correct image digest dynamically. These updates help avoid deployment errors and unnecessary image builds.

**ECR Repository Management:**

* Added a new `aws_ecr_repository` resource to ensure the Docker image repository exists and is properly configured with encryption and image scanning.

**Image Existence and Lookup:**

* Introduced a `data.external` resource to check if the Docker image with the specified tag exists in ECR before attempting to build it.
* Added a `data.aws_ecr_image` resource to safely look up the image digest from ECR, avoiding errors if the image is missing.

**Conditional Image Building:**

* Updated the `null_resource.image_build` so it only triggers the image build script if the image does not already exist in ECR, preventing redundant builds.

**Deployment Reference Update:**

* Changed the `image` field in the Kubernetes deployment resource to use the digest from `data.aws_ecr_image.image.image_digest`, ensuring the deployment always uses the correct image.

**Variable Defaults:**

* Set the default for `image_digest` to an empty string, reflecting that the digest is now dynamically determined rather than statically set.