### PR TITLE
Feature/docker condition

### DIFF
--- a/terraform/buckets.tf
+++ b/terraform/buckets.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket" "project_bucket" {
 }
 
 resource "aws_s3_bucket" "project_bucket_replica" {
-  # depends_on = [aws_s3_bucket.project_bucket]
+  depends_on    = [aws_s3_bucket.project_bucket]
   bucket        = "project-bucket-2727-replica"
   force_destroy = true
   tags = {
@@ -16,6 +16,7 @@ resource "aws_s3_bucket" "project_bucket_replica" {
 }
 
 resource "aws_s3_bucket_public_access_block" "project_bucket_public_access_block" {
+  depends_on              = [aws_s3_bucket.project_bucket]
   bucket                  = aws_s3_bucket.project_bucket.id
   block_public_acls       = true
   block_public_policy     = true
@@ -24,6 +25,7 @@ resource "aws_s3_bucket_public_access_block" "project_bucket_public_access_block
 }
 
 resource "aws_s3_bucket_public_access_block" "project_bucket_replica_public_access_block" {
+  depends_on              = [aws_s3_bucket.project_bucket_replica]
   bucket                  = aws_s3_bucket.project_bucket_replica.id
   block_public_acls       = true
   block_public_policy     = true

--- a/terraform/deploys.tf
+++ b/terraform/deploys.tf
@@ -107,7 +107,7 @@ resource "kubernetes_deployment" "hello_world" {
         container {
           name              = var.deployment
           image_pull_policy = "Always"
-          image             = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.repo_name}:${var.image_tag}@${local.image_digest}"
+          image             = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.repo_name}:${var.image_tag}@${data.aws_ecr_image.image.image_digest}"
           # image             = "adamrocha/hello-world-demo:1.2.0"
           # image             = "hashicorp/http-echo:1.0"
           # args              = ["-text=👋 Hello from Kubernetes!"]

--- a/terraform/deploys.tf
+++ b/terraform/deploys.tf
@@ -107,7 +107,7 @@ resource "kubernetes_deployment" "hello_world" {
         container {
           name              = var.deployment
           image_pull_policy = "Always"
-          image             = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.repo_name}:${var.image_tag}@${data.aws_ecr_image.image.image_digest}"
+          image             = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.repo_name}:${var.image_tag}@${local.image_digest}"
           # image             = "adamrocha/hello-world-demo:1.2.0"
           # image             = "hashicorp/http-echo:1.0"
           # args              = ["-text=👋 Hello from Kubernetes!"]

--- a/terraform/deploys.tf
+++ b/terraform/deploys.tf
@@ -107,7 +107,7 @@ resource "kubernetes_deployment" "hello_world" {
         container {
           name              = var.deployment
           image_pull_policy = "Always"
-          image             = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.repo_name}:${var.image_tag}@${var.image_digest}"
+          image             = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.repo_name}:${var.image_tag}@${data.aws_ecr_image.image.image_digest}"
           # image             = "adamrocha/hello-world-demo:1.2.0"
           # image             = "hashicorp/http-echo:1.0"
           # args              = ["-text=👋 Hello from Kubernetes!"]

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -16,9 +16,9 @@ resource "null_resource" "update_kubeconfig" {
 data "external" "image_exists" {
   program = [
     "bash", "-c", <<EOT
-      REGION=${var.region}
-      REPO_NAME=${var.repo_name}
-      IMAGE_TAG=${var.image_tag}
+      REGION="$REGION"
+      REPO_NAME="$REPO_NAME"
+      IMAGE_TAG="$IMAGE_TAG"
 
       if aws ecr describe-images \
           --region "$REGION" \
@@ -32,10 +32,16 @@ data "external" "image_exists" {
       fi
     EOT
   ]
+  query = {
+    REGION    = var.region
+    REPO_NAME = var.repo_name
+    IMAGE_TAG = var.image_tag
+  }
 }
 
 resource "null_resource" "image_build" {
-  count = data.external.image_exists.result.exists == "false" ? 1 : 0
+  # count = data.external.image_exists.result.exists == "false" ? 1 : 0
+  count = data.external.image_exists.result.exists ? 1 : 0
 
   provisioner "local-exec" {
     command     = "../scripts/docker-image.sh"

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -41,7 +41,7 @@ data "external" "image_exists" {
 
 resource "null_resource" "image_build" {
   # count = data.external.image_exists.result.exists == "false" ? 1 : 0
-  count = data.external.image_exists.result.exists ? 1 : 0
+  count = data.external.image_exists.result.exists == "false" ? 1 : 0
 
   provisioner "local-exec" {
     command     = "../scripts/docker-image.sh"

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -40,7 +40,6 @@ data "external" "image_exists" {
 }
 
 resource "null_resource" "image_build" {
-  # count = data.external.image_exists.result.exists == "false" ? 1 : 0
   count = data.external.image_exists.result.exists == "false" ? 1 : 0
 
   provisioner "local-exec" {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -56,7 +56,7 @@ data "external" "image_exists" {
 
 # Lookup the image safely
 data "aws_ecr_image" "image" {
-  depends_on      = [
+  depends_on = [
     aws_eks_cluster.eks,
     data.external.image_exists
   ]

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -72,7 +72,7 @@ locals {
 
 # Build image only if it doesn't exist
 resource "null_resource" "image_build" {
-  depends_on = [aws_ecr_repository.repo]
+  depends_on = [aws_ecr_repository.repo, data.external.image_exists]
   count      = data.external.image_exists.result.exists == "false" ? 1 : 0
 
   provisioner "local-exec" {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -56,19 +56,16 @@ data "external" "image_exists" {
 
 # Lookup the image safely
 data "aws_ecr_image" "image" {
-  depends_on = [
-    aws_eks_cluster.eks,
-    data.external.image_exists
-  ]
+  depends_on      = [aws_eks_cluster.eks]
   region          = var.region
   repository_name = aws_ecr_repository.repo.name
   image_tag       = var.image_tag
 }
 
 # Use try() to avoid errors when the image doesn't exist
-locals {
-  image_digest = try(data.aws_ecr_image.image.image_digest, "")
-}
+# locals {
+#   image_digest = try(data.aws_ecr_image.image.image_digest, "")
+# }
 
 # Build image only if it doesn't exist
 resource "null_resource" "image_build" {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -65,10 +65,10 @@ data "aws_ecr_image" "image" {
   image_tag       = var.image_tag
 }
 
-# # Use try() to avoid errors when the image doesn't exist
-# locals {
-#   image_digest = try(data.aws_ecr_image.image.image_digest, "")
-# }
+# Use try() to avoid errors when the image doesn't exist
+locals {
+  image_digest = try(data.aws_ecr_image.image.image_digest, "")
+}
 
 # Build image only if it doesn't exist
 resource "null_resource" "image_build" {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -21,10 +21,10 @@ data "external" "image_exists" {
       IMAGE_TAG="$IMAGE_TAG"
 
       if aws ecr describe-images \
-          --region "$REGION" \
-          --repository-name "$REPO_NAME" \
-          --image-ids imageTag="$IMAGE_TAG" \
-          --query "imageDetails[0].imageTags" \
+          --region \"$REGION\" \
+          --repository-name \"$REPO_NAME\" \
+          --image-ids imageTag=\"$IMAGE_TAG\" \
+          --query \"imageDetails[0].imageTags\" \
           --output text >/dev/null 2>&1; then
         echo '{"exists": "true"}'
       else

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -20,12 +20,13 @@ data "external" "image_exists" {
       REPO_NAME="$REPO_NAME"
       IMAGE_TAG="$IMAGE_TAG"
 
-      if aws ecr describe-images \
-          --region \"$REGION\" \
-          --repository-name \"$REPO_NAME\" \
-          --image-ids imageTag=\"$IMAGE_TAG\" \
-          --query \"imageDetails[0].imageTags\" \
-          --output text >/dev/null 2>&1; then
+      IMAGE_COUNT=$(aws ecr describe-images \
+          --region "$REGION" \
+          --repository-name "$REPO_NAME" \
+          --image-ids imageTag="$IMAGE_TAG" \
+          --query "length(imageDetails)" \
+          --output text 2>/dev/null)
+      if [ "$IMAGE_COUNT" -gt 0 ]; then
         echo '{"exists": "true"}'
       else
         echo '{"exists": "false"}'

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -72,7 +72,7 @@ variable "image_tag" {
 
 variable "image_digest" {
   description = "Digest of the Docker image to be used in the deployment"
-  default     = "sha256:f2bf6d4c7470408a1424beee699bfe8642f9f7db4c12a292a89a997677b2a56f"
+  default     = "sha256:9dc736d70b3b5ccc9528e9dbd82c9de90983a517ca651fbb1f640450acdb5c87"
   type        = string
 
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -72,9 +72,8 @@ variable "image_tag" {
 
 variable "image_digest" {
   description = "Digest of the Docker image to be used in the deployment"
-  default     = "sha256:9dc736d70b3b5ccc9528e9dbd82c9de90983a517ca651fbb1f640450acdb5c87"
+  default     = ""
   type        = string
-
 }
 
 variable "tf_state_bucket" {


### PR DESCRIPTION
This pull request improves the reliability and automation of the deployment pipeline by ensuring the ECR repository exists, safely handling Docker image digests, and conditionally building images only when needed. The changes mainly focus on Terraform infrastructure code for Kubernetes deployments and AWS ECR integration.

**ECR Repository Management & Image Handling:**
* Added an `aws_ecr_repository` resource to guarantee the ECR repository exists before deployment, with encryption and image scanning enabled.
* Introduced a data source `external` to check if the Docker image with the specified tag exists in ECR, enabling conditional logic based on image presence.
* Modified the `null_resource.image_build` to only build and push the Docker image if it does not already exist in ECR, preventing unnecessary image builds.

**Kubernetes Deployment Image Reference:**
* Updated the `image` field in the `kubernetes_deployment` resource to use the digest from the `aws_ecr_image` data source, ensuring deployments reference the correct image version.

**Terraform Variable Improvements:**
* Changed the default value of `image_digest` to an empty string to avoid errors when the digest is not available, supporting safer lookups.