### PR TITLE
Test

### DIFF
--- a/.github/workflows/terraform-eks.yml
+++ b/.github/workflows/terraform-eks.yml
@@ -4,9 +4,9 @@ concurrency:
   cancel-in-progress: true
 on:
   push:
-    branches: [dev, test, stage]
+    branches: [main, stage, dev, test]
   pull_request:
-    branches: [dev, test, stage]
+    branches: [main, stage, dev, test]
   delete:
 permissions:
   contents: read

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -21,7 +21,6 @@ resource "aws_eks_cluster" "eks" {
     subnet_ids              = aws_subnet.public[*].id
     endpoint_public_access  = true
     endpoint_private_access = true
-    public_access_cidrs     = ["0.0.0.0/0"]
     # public_access_cidrs     = ["${data.external.my_ip.result.ip}/32"]
   }
 


### PR DESCRIPTION
This pull request updates the EKS Terraform configuration and the GitHub Actions workflow for Terraform deployments. The key changes improve workflow branch targeting and adjust EKS cluster network access.

**Workflow configuration changes:**

* The GitHub Actions workflow in `.github/workflows/terraform-eks.yml` now includes the `main` branch for both `push` and `pull_request` events, ensuring that Terraform actions are triggered for changes to the main branch as well as the existing branches.

**EKS cluster configuration changes:**

* The `public_access_cidrs` setting was removed from the `aws_eks_cluster` resource in `terraform/eks.tf`, which restricts public API server access to the default AWS behavior (previously, it allowed access from all IPs). This increases security by not exposing the EKS API endpoint to the entire internet.