### PR TITLE
Update EKS CI workflow to enhance Docker image build and deployment process

### DIFF
--- a/.github/workflows/terraform-eks.yml
+++ b/.github/workflows/terraform-eks.yml
@@ -9,12 +9,13 @@ on:
     branches: [main, stage, dev]
   delete:
 permissions:
-  contents: read
+  contents: write
 env:
   AWS_REGION: us-east-1
   EKS_CLUSTER_NAME: eks-demo-cluster
   AWS_ACCOUNT_ID: "802645170184"
-  REPO: "hello-world-demo"
+  IMAGE_NAME: "hello-world"
+  REPO_NAME: "hello-world-demo"
   IMAGE_TAG: "1.2.5"
   # IMAGE_TAG: ${{ github.sha }}
 jobs:
@@ -83,34 +84,7 @@ jobs:
       - name: Terraform Apply
         run: terraform apply -auto-approve tfplan
 
-  deploy:
-    if: github.event_name != 'delete'
-    name: Update Deployment
-    runs-on: ubuntu-latest
-    needs: terraform-apply
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
-      - name: Update EKS Deployment with New Image
-        run: |
-          aws eks update-kubeconfig --name ${{ env.EKS_CLUSTER_NAME }} --region ${{ env.AWS_REGION }}
-          kubectl set image deployment/hello-world -n hello-world-ns hello-world=${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.REPO }}:${{ env.IMAGE_TAG }}
-      - name: Verify Kubernetes rollout
-        run: |
-          set -e
-          if ! kubectl rollout status deployment/hello-world -n hello-world-ns --timeout=300s; then
-            echo "Rollout failed, rolling back..."
-            kubectl rollout undo deployment/hello-world -n hello-world-ns
-            echo "::error::Rollback complete. Deployment did not succeed."
-            exit 1
-          fi
-          echo "Rollout succeeded!"
+
 
   check_condition:
     if: github.event_name == 'delete'
@@ -145,3 +119,70 @@ jobs:
         run: terraform init
       - name: Terraform Destroy
         run: terraform destroy -auto-approve -input=false
+
+  docker-build:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    needs: terraform-apply
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - id: 'auth'
+        uses: 'aws-actions/configure-aws-credentials@v4'
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Authenticate Docker to Amazon ECR
+        run: |
+          aws ecr get-login-password --region ${{ env.AWS_REGION }} | docker login --username AWS --password-stdin ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
+
+      - name: Check if image tag exists in Amazon ECR
+        id: image-check
+        run: |
+          IMAGE_PATH="${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.REPO_NAME }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}"
+          IMAGE_TAG="${{ env.IMAGE_TAG }}"
+          if aws ecr describe-images --repository-name ${{ env.REPO_NAME }} --image-ids imageTag=${{ env.IMAGE_TAG }} --region ${{ env.AWS_REGION }} >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Set up Docker Buildx builder and Build Docker image
+        if: steps.image-check.outputs.exists == 'false'
+        run: |
+          if ! docker buildx inspect mybuilder >/dev/null 2>&1; then
+            docker buildx create --name mybuilder --driver docker-container --use
+          fi
+          docker buildx inspect --bootstrap
+          docker buildx build --platform linux/amd64,linux/arm64 -t ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.REPO_NAME }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} -f kube/Dockerfile kube/ --push
+
+  deploy:
+    if: github.event_name != 'delete'
+    name: Update Deployment
+    runs-on: ubuntu-latest
+    needs: docker-build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Update EKS Deployment with New Image
+        run: |
+          aws eks update-kubeconfig --name ${{ env.EKS_CLUSTER_NAME }} --region ${{ env.AWS_REGION }}
+          kubectl set image deployment/hello-world -n hello-world-ns hello-world=${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.REPO_NAME }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+      - name: Verify Kubernetes rollout
+        run: |
+          set -e
+          if ! kubectl rollout status deployment/hello-world -n hello-world-ns --timeout=300s; then
+            echo "Rollout failed, rolling back..."
+            kubectl rollout undo deployment/hello-world -n hello-world-ns
+            echo "::error::Rollback complete. Deployment did not succeed."
+            exit 1
+          fi
+          echo "Rollout succeeded!"


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflow for EKS deployments by improving the Docker image build and deployment process, updating environment variable naming for clarity, and enhancing permissions. The changes introduce a dedicated job for building and pushing Docker images, ensure images are only built if they don't already exist in ECR, and update the deployment job to use the new image path conventions.

**Improvements to Docker image build and deployment:**

* Added a new `docker-build` job that builds and pushes the Docker image to Amazon ECR, including a check to avoid rebuilding images that already exist.
* Refactored the `deploy` job to depend on the `docker-build` job and updated the image path to use `REPO_NAME` and `IMAGE_NAME` for consistency.

**Environment variable and permissions updates:**

* Changed environment variable names from `REPO` to `IMAGE_NAME` and `REPO_NAME` for improved clarity and maintainability.
* Increased GitHub Action permissions from `contents: read` to `contents: write` to support new workflow steps.

**Workflow structure improvements:**

* Reorganized workflow jobs to ensure proper sequencing: `docker-build` now runs after `terraform-apply`, and `deploy` runs after `docker-build`.
* Removed the previous implementation of the `deploy` job and replaced it with the improved version that uses the new image path conventions.